### PR TITLE
Resolve issue 7 by not firing pageTrack on spyrouter init. Fixed a ty…

### DIFF
--- a/src/core/angulartics2.ts
+++ b/src/core/angulartics2.ts
@@ -78,22 +78,13 @@ export class Angulartics2 {
 					let url: string = location.prepareExternalUrl(route);
 					if (this.settings.pageTracking.autoTrackVirtualPages && !this.matchesExcludedRoute(url)) {
 						this.pageTrack.next({
-							path: this.settings.pageTracking.basePath.lenght ? this.settings.pageTracking.basePath + route : location.prepareExternalUrl(url),
+							path: this.settings.pageTracking.basePath.length ? this.settings.pageTracking.basePath + route : location.prepareExternalUrl(url),
 							location: location
 						});
 					}
 				});
 			}
 		});
-
-		if (!this.settings.developerMode) {
-			if (this.settings.pageTracking.autoTrackVirtualPages && !this.matchesExcludedRoute(location.path())) {
-				this.pageTrack.next({
-					path: this.settings.pageTracking.basePath.lenght ? this.settings.pageTracking.basePath + location.path() : location.prepareExternalUrl(location.path()),
-					location: location
-				});
-			}
-		}
 	}
 
 	virtualPageviews(value: boolean) {


### PR DESCRIPTION
Resolve issue 7 by not firing pageTrack on spyrouter init. Fixed a typo too.

Resolve #7 

Removed the initial call to ```this.pageTrack.next()``` on ```spyrouter(...)``` initialization. The call to this.pageTrack.next() is already done by the subscription to the router.