### PR TITLE
Update to angular2@beta.17 with compatible RxJS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,8 @@
     "Chris Soyars <ctso@ctso.me> (https://github.com/ctso)",
     "Fil Maj <maj.fil@gmail.com> (https://github.com/filmaj)"
   ],
-  "dependencies": {},
   "devDependencies": {
-    "angular2": "2.0.0-beta.16",
+    "angular2": "^2.0.0-beta.17",
     "commitizen": "~2.7.6",
     "cz-conventional-changelog": "~1.1.5",
     "es6-shim": "^0.35.0",
@@ -46,7 +45,7 @@
     "karma-jasmine": "~0.3.8",
     "karma-typescript-preprocessor": "0.0.21",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.2",
+    "rxjs": "^5.0.0-beta.6",
     "semantic-release": "^4.3.5",
     "systemjs": "~0.19.25",
     "tslint": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"index.ts",
 	"index.d.ts",
 	"src"
-  ]
+  ],
   "description": "Vendor-agnostic web analytics for Angular2 applications",
   "homepage": "http://angulartics.github.io/",
   "author": "João Ribeiro <jonnybgod@gmail.com> (http://github.com/JonnyBGod)",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angulartics2",
+  "version": "1.0.0",
   "description": "Vendor-agnostic web analytics for Angular2 applications",
   "homepage": "http://angulartics.github.io/",
   "author": "João Ribeiro <jonnybgod@gmail.com> (http://github.com/JonnyBGod)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,12 @@
 {
   "name": "angulartics2",
   "version": "1.0.0",
+  "files": [
+	"index.js",
+	"index.ts",
+	"index.d.ts",
+	"src"
+  ]
   "description": "Vendor-agnostic web analytics for Angular2 applications",
   "homepage": "http://angulartics.github.io/",
   "author": "João Ribeiro <jonnybgod@gmail.com> (http://github.com/JonnyBGod)",

--- a/src/core/angulartics2.ts
+++ b/src/core/angulartics2.ts
@@ -1,5 +1,5 @@
 import {Injectable} from 'angular2/core';
-import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import {ReplaySubject} from 'rxjs/ReplaySubject';
 import {Router} from 'angular2/router';
 import {Location} from 'angular2/platform/common';
 

--- a/src/core/angulartics2.ts
+++ b/src/core/angulartics2.ts
@@ -19,52 +19,52 @@ export class Angulartics2 {
 	/*
 		@Param: ({url: string, location: Location})
 	 */
-	public pageTrack: ReplaySubject<any> = new ReplaySubject();
+	public pageTrack: ReplaySubject<any> = new ReplaySubject<any>();
 
 	/*
 		@Param: ({action: any, properties: any})
 	 */
-	public eventTrack: ReplaySubject<any> = new ReplaySubject();
+	public eventTrack: ReplaySubject<any> = new ReplaySubject<any>();
 
 	/*
 		@Param: (properties: any)
 	 */
-	public exceptionTrack: ReplaySubject<any> = new ReplaySubject();
+	public exceptionTrack: ReplaySubject<any> = new ReplaySubject<any>();
 
 	/*
 		@Param: (alias: string)
 	 */
-	public setAlias: ReplaySubject<string> = new ReplaySubject();
+	public setAlias: ReplaySubject<string> = new ReplaySubject<string>();
 
 	/*
 		@Param: (userId: string)
 	 */
-	public setUsername: ReplaySubject<string> = new ReplaySubject();
+	public setUsername: ReplaySubject<string> = new ReplaySubject<string>();
 
 	/*
 		@Param: ({action: any, properties: any})
 	 */
-	public setUserProperties: ReplaySubject<any> = new ReplaySubject();
+	public setUserProperties: ReplaySubject<any> = new ReplaySubject<any>();
 
 	/*
 		@Param: (properties: any)
 	 */
-	public setUserPropertiesOnce: ReplaySubject<any> = new ReplaySubject();
+	public setUserPropertiesOnce: ReplaySubject<any> = new ReplaySubject<any>();
 
 	/*
 		@Param: (properties: any)
 	 */
-	public setSuperProperties: ReplaySubject<any> = new ReplaySubject();
+	public setSuperProperties: ReplaySubject<any> = new ReplaySubject<any>();
 
 	/*
 		@Param: (properties: any)
 	 */
-	public setSuperPropertiesOnce: ReplaySubject<any> = new ReplaySubject();
+	public setSuperPropertiesOnce: ReplaySubject<any> = new ReplaySubject<any>();
 
 	/*
 		@Param: (properties: any)
 	 */
-	public userTimings: ReplaySubject<any> = new ReplaySubject();
+	public userTimings: ReplaySubject<any> = new ReplaySubject<any>();
 
 	constructor(router: Router, location: Location) {
 	  this.spyRouter(router, location);


### PR DESCRIPTION
Hi,

  Just started using angulartics as it looks just what I need.

  However, I am trying to keep my app up to date with the latest angular beta to avoid a load of breaking changes later down the line. One issue bringing in angulartics was it references RxJS version 2, which is the old version of Rx referenced by Angular.

  We have to use RxJS Beta 6, which changes the location of the ReplaySubject.

  The main change here is modifying the import for RxJS ReplaySubject.

Thanks for the library.