### PR TITLE
Fix wrong import

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ export class SongDownloadBox {}
 // bootstrap
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { Angulartics2, Angulartics2On } from 'angulartics2/src/core/angulartics2';
+import { Angulartics2 } from 'angulartics2/src/core/angulartics2';
+import { Angulartics2On } from 'angulartics2/src/core/angulartics2On';
 
 @NgModule({
   imports: [ BrowserModule ],


### PR DESCRIPTION
If I were you I would create an index.ts file inside the /core folder so we can do this:

import { Angulartics2, Angulartics2On } from 'angulartics2/src/core'