### PR TITLE
Standardized the GTM Page View variable instead of the GA pageview va…

### DIFF
--- a/src/providers/gtm/angulartics2-gtm.ts
+++ b/src/providers/gtm/angulartics2-gtm.ts
@@ -36,7 +36,7 @@ export class Angulartics2GoogleTagManager {
   pageTrack(path: string) {
     if (typeof dataLayer !== 'undefined' && dataLayer) {
       dataLayer.push({
-        'event': 'pageview',
+        'event': 'Page View',
         'content-name': path,
         'userId': this.angulartics2.settings.gtm.userId
       });


### PR DESCRIPTION
Sorry last update I think...  After working with this in production found that I was using the GA format for pageviews instead of the GTM version, so I updated it to reflect GTM.