### PR TITLE
Update to angulartics2-gtm.ts to fix Event Labels

### DIFF
--- a/src/providers/gtm/angulartics2-gtm.spec.ts
+++ b/src/providers/gtm/angulartics2-gtm.spec.ts
@@ -43,7 +43,7 @@ describe('Angulartics2GoogleTagManager', () => {
           fixture = createRoot(RootCmp);
           angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
           advance(fixture);
-          expect(dataLayer).toContain({ event: 'interaction', target: 'cat', action: 'do', targetProperties: undefined, value: undefined, interactionType: undefined, userId: null });
+          expect(dataLayer).toContain({ event: 'interaction', target: 'cat', action: 'do', label: undefined, value: undefined, interactionType: undefined, userId: null });
       })));
 
   it('should track exceptions',

--- a/src/providers/gtm/angulartics2-gtm.spec.ts
+++ b/src/providers/gtm/angulartics2-gtm.spec.ts
@@ -52,7 +52,7 @@ describe('Angulartics2GoogleTagManager', () => {
           fixture = createRoot(RootCmp);
           angulartics2.exceptionTrack.next({ appId: 'app', appName: 'Test App', appVersion: '0.1' });
           advance(fixture);
-          expect(dataLayer).toContain({ event: 'interaction', target: 'Exception', action: 'Exception thrown for Test App <app@0.1>', targetProperties: undefined, value: undefined, interactionType: undefined, userId: null });
+          expect(dataLayer).toContain({ event: 'interaction', target: 'Exception', action: 'Exception thrown for Test App <app@0.1>', label: undefined, value: undefined, interactionType: undefined, userId: null });
       })));
 
   it('should set username',

--- a/src/providers/gtm/angulartics2-gtm.ts
+++ b/src/providers/gtm/angulartics2-gtm.ts
@@ -60,7 +60,7 @@ export class Angulartics2GoogleTagManager {
         event: properties.event || 'interaction',
         target: properties.category || 'Event',
         action: action,
-        targetProperties: properties.label,
+        label: properties.label,
         value: properties.value,
         interactionType: properties.noninteraction,
         userId: this.angulartics2.settings.gtm.userId


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Issue is Event Tracking using the GTM provider does not send the label to the dataLayer - more can be seen here: #22 


* **What is the new behavior (if this is a feature change)?**
Event Label is correctly sent to the dataLayer


* **Other information**:

Event label was being passed to GTM on line 63, the code read:
```javascript 
targetProperties: properties.label,
```

When it should have been:
```javascript 
label: properties.label,
```