### PR TITLE
fix(provider): removed erroneous validation from exceptionTrack

### DIFF
--- a/src/providers/ga/angulartics2-ga.spec.ts
+++ b/src/providers/ga/angulartics2-ga.spec.ts
@@ -52,9 +52,9 @@ describe('Angulartics2GoogleAnalytics', () => {
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
         (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
           fixture = createRoot(RootCmp);
-          angulartics2.exceptionTrack.next({ appId: 'app', appName: 'Test App', appVersion: '0.1' });
+          angulartics2.exceptionTrack.next({ fatal: true, description: 'test' });
           advance(fixture);
-          expect(ga).toHaveBeenCalledWith('send', 'exception', { appId: 'app', appName: 'Test App', appVersion: '0.1', exFatal: true, exDescription: undefined });
+          expect(ga).toHaveBeenCalledWith('send', 'exception', { exFatal: true, exDescription: 'test' });
       })));
 
   it('should set username',

--- a/src/providers/ga/angulartics2-ga.ts
+++ b/src/providers/ga/angulartics2-ga.ts
@@ -109,27 +109,28 @@ export class Angulartics2GoogleAnalytics {
    * Exception Track Event in GA
    * @name exceptionTrack
    *
-   * @param {object} properties Comprised of the mandatory fields 'appId' (string), 'appName' (string) and 'appVersion' (string) and 
-   * optional  fields 'fatal' (boolean) and 'description' (string)
+   * @param {object} properties Comprised of the optional fields:
+   *     'fatal' (string),
+   *     'description' (string)
    *
    * @https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions
    *
    * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/events
    */
   exceptionTrack(properties: any) {
-    if (!properties || !properties.appId || !properties.appName || !properties.appVersion) {
-      console.error('Must be setted appId, appName and appVersion.');
-      return;
-    }
-
     if (properties.fatal === undefined) {
       console.log('No "fatal" provided, sending with fatal=true');
-      properties.exFatal = true;
+      properties.fatal = true;
     }
 
     properties.exDescription = properties.description;
 
-    ga('send', 'exception', properties);
+    var eventOptions = {
+      exFatal: properties.fatal,
+      exDescription: properties.description
+    };
+
+    ga('send', 'exception', eventOptions);
   }
 
   setUsername(userId: string) {


### PR DESCRIPTION
The exceptionTrack method in Angular2GoogleAnalytics was checking for three fields that were not
used anywhere in the method. Removed them. Also corrected the unit test for this method
appropriately.

Issue #95 