### PR TITLE
Add Adobe Analytics (Omniture) Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ this.angulartics2.eventTrack.next({ action: 'myAction', properties: { category: 
 * Baidu Analytics
 * Facebook Pixel
 * Application Insights
+* Adobe Analytics (Omniture)
 
 ### For other providers
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-"version": "0.0.0",
   "name": "angulartics2",
   "description": "Vendor-agnostic web analytics for Angular2 applications",
   "homepage": "http://angulartics.github.io/",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+"version": "0.0.0",
   "name": "angulartics2",
   "description": "Vendor-agnostic web analytics for Angular2 applications",
   "homepage": "http://angulartics.github.io/",

--- a/src/providers/adobeanalytics/angulartics2-adobeanalytics.spec.ts
+++ b/src/providers/adobeanalytics/angulartics2-adobeanalytics.spec.ts
@@ -1,0 +1,94 @@
+import { Location } from '@angular/common';
+import { SpyLocation } from '@angular/common/testing';
+import { TestBed, ComponentFixture, fakeAsync, inject } from '@angular/core/testing';
+
+import { TestModule, RootCmp, advance, createRoot } from '../../test.mocks';
+
+import { Angulartics2 } from '../../core/angulartics2';
+import { Angulartics2AdobeAnalytics } from './angulartics2-adobeanalytics';
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
+declare var window: any;
+
+export class MockLocation extends SpyLocation {
+  path() {
+    return 'http://test.com/test#pagename';
+  }
+}
+
+describe('Angulartics2AdobeAnalytics', () => {
+  var s: any;
+  var fixture: ComponentFixture<any>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        TestModule
+      ],
+      providers: [
+        { provide: Location, useClass: MockLocation },
+        Angulartics2AdobeAnalytics
+      ]
+    });
+
+    window.s = s = jasmine.createSpyObj('s',['clearVars','t','tl']);
+    
+  });
+
+  it('should track pages',
+    fakeAsync(inject([Location, Angulartics2, Angulartics2AdobeAnalytics],
+      (location: Location, angulartics2: Angulartics2, angulartics2AdobeAnalytics: Angulartics2AdobeAnalytics) => {
+          fixture = createRoot(RootCmp);
+          angulartics2.pageTrack.next({ path: '/abc' });
+          advance(fixture);
+          expect(s.clearVars).toHaveBeenCalled();
+          expect(s.t).toHaveBeenCalledWith({pageName:'/abc'});
+  })));
+
+  it('should track events with no delay',
+    fakeAsync(inject([Location, Angulartics2, Angulartics2AdobeAnalytics],
+      (location: Location, angulartics2: Angulartics2, angulartics2AdobeAnalytics: Angulartics2AdobeAnalytics) => {
+          fixture = createRoot(RootCmp);
+          
+          angulartics2.eventTrack.next({ action: 'do', properties: { disableDelay: true } });
+          advance(fixture);
+          expect(s.tl).toHaveBeenCalledWith(true, 'o', 'do');
+          expect(window.s.pageName).toEqual('pagename');
+  })));
+
+  it('should track events with custom properties',
+    fakeAsync(inject([Location, Angulartics2, Angulartics2AdobeAnalytics],
+      (location: Location, angulartics2: Angulartics2, angulartics2AdobeAnalytics: Angulartics2AdobeAnalytics) => {
+          fixture = createRoot(RootCmp);
+          
+          angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat', prop1: 'user1234' } });
+          advance(fixture);
+          expect(window.s.prop1).toEqual('user1234');
+          expect(window.s.category).toEqual('cat');
+          expect(s.tl).toHaveBeenCalledWith(jasmine.any(Object), 'o', 'do');
+  })));
+
+  it('should track events',
+    fakeAsync(inject([Location, Angulartics2, Angulartics2AdobeAnalytics],
+        (location: Location, angulartics2: Angulartics2, angulartics2AdobeAnalytics: Angulartics2AdobeAnalytics) => {
+          fixture = createRoot(RootCmp);
+          angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
+          advance(fixture);
+          expect(s.tl).toHaveBeenCalledWith(jasmine.any(Object), 'o', 'do');
+          expect(window.s.pageName).toEqual('pagename');
+  })));
+
+  it('should set user porperties',
+    fakeAsync(inject([Location, Angulartics2, Angulartics2AdobeAnalytics],
+        (location: Location, angulartics2: Angulartics2, angulartics2AdobeAnalytics: Angulartics2AdobeAnalytics) => {
+          fixture = createRoot(RootCmp);
+          angulartics2.setUserProperties.next({ evar1: 'test' });
+          advance(fixture);
+          expect(s.evar1).toEqual('test');
+          angulartics2.setUserProperties.next({ prop1: 'test' });
+          advance(fixture);
+          expect(s.prop1).toEqual('test');
+  })));
+
+
+});

--- a/src/providers/adobeanalytics/angulartics2-adobeanalytics.ts
+++ b/src/providers/adobeanalytics/angulartics2-adobeanalytics.ts
@@ -13,13 +13,6 @@ export class Angulartics2AdobeAnalytics {
   ) {
     this.angulartics2.settings.pageTracking.trackRelativePath = true;
 
-    // Set the default settings for this module
-    this.angulartics2.settings.s = {
-      // array of additional account names (only works for analyticsjs)
-      additionalAccountNames: [],
-      userId: null
-    };
-
     this.angulartics2.pageTrack.subscribe((x: any) => this.pageTrack(x.path));
 
     this.angulartics2.eventTrack.subscribe((x: any) => this.eventTrack(x.action, x.properties));

--- a/src/providers/adobeanalytics/angulartics2-adobeanalytics.ts
+++ b/src/providers/adobeanalytics/angulartics2-adobeanalytics.ts
@@ -47,11 +47,11 @@ export class Angulartics2AdobeAnalytics {
       }
       if (action) {
         // if linkName property is passed, use that; otherwise, the action is the linkName
-        var linkName = (properties['linkName']) ? properties['linkName'] : action;
+        const linkName = (properties['linkName']) ? properties['linkName'] : action;
         // note that 'this' should refer the link element, but we can't get that in this function. example:
         // <a href="http://anothersite.com" onclick="s.tl(this,'e','AnotherSite',null)">
         // if disableDelay property is passed, use that to turn off/on the 500ms delay; otherwise, it uses this
-        var disableDelay = !!properties['disableDelay'] ? true : this;
+        const disableDelay = !!properties['disableDelay'] ? true : this;
         // if action property is passed, use that; otherwise, the action remains unchanged
         if (properties['action']) {
           action = properties['action'];

--- a/src/providers/adobeanalytics/angulartics2-adobeanalytics.ts
+++ b/src/providers/adobeanalytics/angulartics2-adobeanalytics.ts
@@ -1,0 +1,99 @@
+import { Injectable } from '@angular/core';
+import { Location } from '@angular/common';
+import { Angulartics2 } from '../../core/angulartics2';
+
+declare var s: any;
+
+@Injectable()
+export class Angulartics2AdobeAnalytics {
+
+  constructor(
+    private angulartics2: Angulartics2,
+    private location: Location
+  ) {
+    this.angulartics2.settings.pageTracking.trackRelativePath = true;
+
+    // Set the default settings for this module
+    this.angulartics2.settings.s = {
+      // array of additional account names (only works for analyticsjs)
+      additionalAccountNames: [],
+      userId: null
+    };
+
+    this.angulartics2.pageTrack.subscribe((x: any) => this.pageTrack(x.path));
+
+    this.angulartics2.eventTrack.subscribe((x: any) => this.eventTrack(x.action, x.properties));
+
+    this.angulartics2.setUserProperties.subscribe((x: any) => this.setUserProperties(x));
+  }
+
+  pageTrack(path: string) {
+    if (typeof s !== 'undefined' && s) {
+      s.clearVars();
+      s.t({pageName:path});
+    }
+  }
+
+  /**
+   * Track Event in Adobe Analytics
+   * @name eventTrack
+   *
+   * @param {string} action Required 'action' (string) associated with the event
+   * @param {object} properties Comprised of the mandatory field 'category' (string) and optional  fields 'label' (string), 'value' (integer) and 'noninteraction' (boolean)
+   *
+   * @link https://marketing.adobe.com/resources/help/en_US/sc/implement/js_implementation.html
+   */
+  eventTrack(action: string, properties: any) {
+    if (!properties) {
+      properties = properties || {};
+    }
+
+    if (typeof s !== 'undefined' && s) {
+      if (typeof properties === 'object') {
+        this.setUserProperties(properties);
+      }
+      if (action) {
+        // if linkName property is passed, use that; otherwise, the action is the linkName
+        var linkName = (properties['linkName']) ? properties['linkName'] : action;
+        // note that 'this' should refer the link element, but we can't get that in this function. example:
+        // <a href="http://anothersite.com" onclick="s.tl(this,'e','AnotherSite',null)">
+        // if disableDelay property is passed, use that to turn off/on the 500ms delay; otherwise, it uses this
+        var disableDelay = !!properties['disableDelay'] ? true : this;
+        // if action property is passed, use that; otherwise, the action remains unchanged
+        if (properties['action']) {
+          action = properties['action'];
+        }
+        this.setPageName();
+
+        if (action.toUpperCase() === "DOWNLOAD") {
+          s.tl(disableDelay,'d',linkName);
+        } else if (action.toUpperCase() === "EXIT") {
+          s.tl(disableDelay,'e',linkName);
+        } else {
+          s.tl(disableDelay,'o',linkName);
+        }
+      }
+    }
+  }
+
+  private setPageName() {
+    const path = this.location.path(true);
+    const hashNdx = path.indexOf('#');
+    if (hashNdx > 0 && hashNdx < path.length) {
+      s.pageName = path.substring(hashNdx+1);
+    } else {
+      s.pageName = path;
+    }
+  }
+
+  setUserProperties(properties: any) {
+    if (typeof properties === 'object') {
+      for (let key in properties) {
+        if (properties.hasOwnProperty(key)) {
+          s[key] = properties[key];
+        }
+      }
+    }
+  }
+
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -7,3 +7,4 @@ export * from './piwik/angulartics2-piwik';
 export * from './segment/angulartics2-segment';
 export * from './facebook/angulartics2-facebook';
 export * from './appinsights/angulartics2-appinsights';
+export * from './adobeanalytics/angulartics2-adobeanalytics';


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds provider for Adobe Analytics that supports page and event tracking.


* **What is the current behavior?** (You can also link to an open issue here)
Adobe Analytics not currently supported #110 


* **What is the new behavior (if this is a feature change)?**
Adobe Analytics support.


* **Other information**:
