### PR TITLE
Update Hubspot plugin to undefined check global variable

### DIFF
--- a/src/providers/hubspot/angulartics2-hubspot.ts
+++ b/src/providers/hubspot/angulartics2-hubspot.ts
@@ -10,7 +10,7 @@ export class Angulartics2Hubspot {
   constructor(
     private angulartics2: Angulartics2
   ) {
-    if (typeof (_hsq) === undefined) {
+    if (typeof _hsq === "undefined") {
       _hsq = [];
     }
 
@@ -22,20 +22,20 @@ export class Angulartics2Hubspot {
   }
 
   pageTrack(path: string, location: any) {
-    if (_hsq !== undefined) {
+    if (typeof _hsq !== "undefined") {
       _hsq.push(['setPath', path]);
       _hsq.push(['trackPageView']);
     }
   }
 
   eventTrack(action: string, properties: any) {
-    if (_hsq !== undefined) {
+    if (typeof _hsq !== "undefined") {
       _hsq.push(['trackEvent', properties]);
     }
   }
 
   setUserProperties(properties: any) {
-    if (_hsq !== undefined) {
+    if (typeof _hsq !== "undefined") {
       _hsq.push(['identify', properties]);
     }
   }

--- a/src/providers/hubspot/angulartics2-hubspot.ts
+++ b/src/providers/hubspot/angulartics2-hubspot.ts
@@ -10,7 +10,7 @@ export class Angulartics2Hubspot {
   constructor(
     private angulartics2: Angulartics2
   ) {
-    if (typeof (_hsq) === 'undefined') {
+    if (typeof (_hsq) === undefined) {
       _hsq = [];
     }
 
@@ -22,15 +22,21 @@ export class Angulartics2Hubspot {
   }
 
   pageTrack(path: string, location: any) {
+    if (_hsq !== undefined) {
       _hsq.push(['setPath', path]);
-    _hsq.push(['trackPageView']);
+      _hsq.push(['trackPageView']);
+    }
   }
 
   eventTrack(action: string, properties: any) {
-    _hsq.push(['trackEvent', properties]);
+    if (_hsq !== undefined) {
+      _hsq.push(['trackEvent', properties]);
+    }
   }
 
   setUserProperties(properties: any) {
-    _hsq.push(['identify', properties]);
+    if (_hsq !== undefined) {
+      _hsq.push(['identify', properties]);
+    }
   }
 }

--- a/src/providers/hubspot/angulartics2-hubspot.ts
+++ b/src/providers/hubspot/angulartics2-hubspot.ts
@@ -10,7 +10,7 @@ export class Angulartics2Hubspot {
   constructor(
     private angulartics2: Angulartics2
   ) {
-    if (typeof _hsq === "undefined") {
+    if (typeof _hsq === 'undefined') {
       _hsq = [];
     }
 
@@ -22,20 +22,20 @@ export class Angulartics2Hubspot {
   }
 
   pageTrack(path: string, location: any) {
-    if (typeof _hsq !== "undefined") {
+    if (typeof _hsq !== 'undefined') {
       _hsq.push(['setPath', path]);
       _hsq.push(['trackPageView']);
     }
   }
 
   eventTrack(action: string, properties: any) {
-    if (typeof _hsq !== "undefined") {
+    if (typeof _hsq !== 'undefined') {
       _hsq.push(['trackEvent', properties]);
     }
   }
 
   setUserProperties(properties: any) {
-    if (typeof _hsq !== "undefined") {
+    if (typeof _hsq !== 'undefined') {
       _hsq.push(['identify', properties]);
     }
   }


### PR DESCRIPTION
I added this because when I was running tests on my local app without having a global variable loading the plugin would break tests.  Instead of requiring app writers to worry about this, it makes more sense to add undefined checks here.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix
* **What is the new behavior (if this is a feature change)?**
Fixes tests on other apps that use this plugin