### PR TITLE
feat(provider): add custom dimensions support to piwik

### DIFF
--- a/src/providers/piwik/angulartics2-piwik.spec.ts
+++ b/src/providers/piwik/angulartics2-piwik.spec.ts
@@ -55,7 +55,7 @@ describe('Angulartics2Piwik', () => {
       expect(_paq).toContain(['setUserId', 'testUser']);
     })));
 
-  it('should set user properties',
+  it('should set user properties as custom variable',
     fakeAsync(inject([Location, Angulartics2, Angulartics2Piwik],
     (location: Location, angulartics2: Angulartics2, angulartics2Piwik: Angulartics2Piwik) => {
       fixture = createRoot(RootCmp);
@@ -63,5 +63,16 @@ describe('Angulartics2Piwik', () => {
       advance(fixture);
       expect(_paq).toContain(['setCustomVariable', { userId: '1', firstName: 'John', lastName: 'Doe' }]);
     })));
+
+    it('should set user properties as custom dimension',
+    fakeAsync(inject([Location, Angulartics2, Angulartics2Piwik],
+        (location: Location, angulartics2: Angulartics2, angulartics2Piwik: Angulartics2Piwik) => {
+            fixture = createRoot(RootCmp);
+            angulartics2.setUserProperties.next({dimension1: 'v1.2.3', dimension2: 'german', dimension43: 'green'});
+            advance(fixture);
+            expect(_paq).toContain(['setCustomDimension', 1, 'v1.2.3']);
+            expect(_paq).toContain(['setCustomDimension', 2, 'german']);
+            expect(_paq).toContain(['setCustomDimension', 43, 'green']);
+        })));
 
 });

--- a/src/providers/piwik/angulartics2-piwik.ts
+++ b/src/providers/piwik/angulartics2-piwik.ts
@@ -60,14 +60,37 @@ export class Angulartics2Piwik {
     }
   }
 
+  /**
+   * Sets custom dimensions if at least one property has the key "dimension<n>",
+   * e.g. dimension10. If there are custom dimensions, any other property is ignored.
+   *
+   * If there are no custom dimensions in the given properties object, the properties
+   * object is saved as a custom variable.
+   *
+   * If in doubt, prefer custom dimensions.
+   * @see https://piwik.org/docs/custom-variables/
+   */
   setUserProperties(properties: any) {
     try {
-      _paq.push(['setCustomVariable', properties]);
+      const dimensions = this.setCustomDimensions(properties);
+      if (dimensions.length === 0) {
+        _paq.push(['setCustomVariable', properties]);
+      }
     } catch (e) {
       if (!(e instanceof ReferenceError)) {
         throw e;
       }
     }
+  }
+
+  private setCustomDimensions(properties: any): string[] {
+    const dimensionRegex: RegExp = /dimension[1-9]\d*/;
+    const dimensions = Object.keys(properties).filter(key => dimensionRegex.exec(key));
+    dimensions.forEach(dimension => {
+      const number = Number(dimension.substr(9));
+      _paq.push(['setCustomDimension', number, properties[dimension]]);
+    });
+    return dimensions;
   }
 
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature
* **What is the current behavior?** (You can also link to an open issue here)
#135
* **What is the new behavior (if this is a feature change)?**
  * (almost) fully downward compatible: setUserProperties still sets a custom variable as long as no property has a key like dimension{number}, like dimension12
  * if properties contains at least one key like dimension{number}, all those are set as custom dimensions, any other keys are ignored
