### PR TITLE
feat(provider): hitCallback function for ga

### DIFF
--- a/src/providers/ga/angulartics2-ga.spec.ts
+++ b/src/providers/ga/angulartics2-ga.spec.ts
@@ -45,8 +45,18 @@ describe('Angulartics2GoogleAnalytics', () => {
           fixture = createRoot(RootCmp);
           angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
           advance(fixture);
-          expect(ga).toHaveBeenCalledWith('send', 'event', { eventCategory: 'cat', eventAction: 'do', eventLabel: undefined, eventValue: undefined, nonInteraction: undefined, page: '/context.html', userId: null });
+          expect(ga).toHaveBeenCalledWith('send', 'event', { eventCategory: 'cat', eventAction: 'do', eventLabel: undefined, eventValue: undefined, nonInteraction: undefined, page: '/context.html', userId: null, hitCallback: undefined });
       })));
+       
+  it('should track events with hitCallback',
+    fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
+        (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
+          fixture = createRoot(RootCmp);
+          const callback = function() { };          
+          angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat', hitCallback: callback } });
+          advance(fixture);
+          expect(ga).toHaveBeenCalledWith('send', 'event', { eventCategory: 'cat', eventAction: 'do', eventLabel: undefined, eventValue: undefined, nonInteraction: undefined, page: '/context.html', userId: null, hitCallback: callback });
+      })));      
 
   it('should track exceptions',
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],

--- a/src/providers/ga/angulartics2-ga.ts
+++ b/src/providers/ga/angulartics2-ga.ts
@@ -85,7 +85,8 @@ export class Angulartics2GoogleAnalytics {
         eventValue: properties.value,
         nonInteraction: properties.noninteraction,
         page: properties.page || location.hash.substring(1) || location.pathname,
-        userId: this.angulartics2.settings.ga.userId
+        userId: this.angulartics2.settings.ga.userId,
+        hitCallback: properties.hitCallback
       };
 
       // add custom dimensions and metrics


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  feature

* **What is the current behavior?** (You can also link to an open issue here)
  hitCallback property is ignored, see see: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#hitCallback

* **What is the new behavior (if this is a feature change)?**
  hitCallback property is taken into account, this allows tracking of outbound links, see https://support.google.com/analytics/answer/1136920?hl=en

* **Other information**:
  functionallity fully tested, impatient people can use this tarball: https://github.com/JohannesHoppe/angulartics2/releases/tag/v.2.2.3-fork