### PR TITLE
build(dist): Build es5 and es2015 output versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,11 +91,12 @@
     "clean:install": "npm set progress=false && npm i",
     "commit": "git-cz",
     "prebuild": "npm run rimraf -- dist",
-    "build": "ngc && webpack",
+    "build": "ngc --p tsconfig.es5.json && ngc --p tsconfig.es2015.json && webpack",
     "semantic-release": "semantic-release pre && npm run build && npm publish && semantic-release post"
   },
   "main": "dist/core.umd.js",
-  "module": "dist/index.js",
+  "module": "dist/es5/index.js",
+  "es2015": "dist/index.js",
   "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",

--- a/tsconfig.es2015.json
+++ b/tsconfig.es2015.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "es2015"
+  },
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true,
+    "skipTemplateCodegen": true
+  }
+}

--- a/tsconfig.es5.json
+++ b/tsconfig.es5.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/es5"
+  },
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true,
+    "skipTemplateCodegen": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "noImplicitAny": true,
-    "module": "es2015",
     "target": "es5",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
@@ -22,9 +21,5 @@
     "node_modules",
     "bundles"
   ],
-  "compileOnSave": false,
-  "angularCompilerOptions": {
-    "strictMetadataEmit": true,
-    "skipTemplateCodegen": true
-  }
+  "compileOnSave": false
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
* Output JS is using `es2015` module syntax


* **What is the new behavior (if this is a feature change)?**
* Output JS is using `commonjs` module syntax


* **Other information**:
* Couldn't use angulartics2 using Angular Universal in `node` when output JS is using `es2015` module syntax