### PR TITLE
Fixed "ReferenceError: s is not defined"

### DIFF
--- a/src/providers/adobeanalytics/angulartics2-adobeanalytics.ts
+++ b/src/providers/adobeanalytics/angulartics2-adobeanalytics.ts
@@ -80,10 +80,12 @@ export class Angulartics2AdobeAnalytics {
   }
 
   setUserProperties(properties: any) {
-    if (typeof properties === 'object') {
-      for (let key in properties) {
-        if (properties.hasOwnProperty(key)) {
-          s[key] = properties[key];
+    if (typeof s !== 'undefined' && s) {
+      if (typeof properties === 'object') {
+        for (let key in properties) {
+          if (properties.hasOwnProperty(key)) {
+            s[key] = properties[key];
+          }
         }
       }
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
If you try to set the user properties before 's' has been async loaded, it throws and exception that 's' is not defined.


* **What is the new behavior (if this is a feature change)?**
The new behavior checks if 's' is available.


* **Other information**:
