### PR TITLE
perf(core): rxjs lettable operators, types on replay subjects

### DIFF
--- a/src/lib/core/angulartics2.ts
+++ b/src/lib/core/angulartics2.ts
@@ -1,8 +1,8 @@
-import { Injectable } from '@angular/core';
 import { Location } from '@angular/common';
-import { Router, NavigationEnd } from '@angular/router';
-import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { Injectable } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
 
 @Injectable()
 export class Angulartics2 {

--- a/src/lib/core/angulartics2.ts
+++ b/src/lib/core/angulartics2.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { Location } from '@angular/common';
 import { Router, NavigationEnd } from '@angular/router';
-import { filter } from 'rxjs/operator/filter';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { filter } from 'rxjs/operators';
 
 @Injectable()
 export class Angulartics2 {
@@ -16,67 +16,29 @@ export class Angulartics2 {
     developerMode: false
   };
 
-  /*
-    @Param: ({url: string, location: Location})
-   */
-  public pageTrack: ReplaySubject<any> = new ReplaySubject(10);
-
-  /*
-    @Param: ({action: any, properties: any})
-   */
-  public eventTrack: ReplaySubject<any> = new ReplaySubject(10);
-
-  /*
-    @Param: (properties: any)
-   */
-  public exceptionTrack: ReplaySubject<any> = new ReplaySubject(10);
-
-  /*
-    @Param: (alias: string)
-   */
-  public setAlias: ReplaySubject<any> = new ReplaySubject(10);
-
-  /*
-    @Param: (userId: string)
-   */
-  public setUsername: ReplaySubject<any> = new ReplaySubject(10);
-
-  /*
-    @Param: ({action: any, properties: any})
-   */
-  public setUserProperties: ReplaySubject<any> = new ReplaySubject(10);
-
-  /*
-    @Param: (properties: any)
-   */
-  public setUserPropertiesOnce: ReplaySubject<any> = new ReplaySubject(10);
-
-  /*
-    @Param: (properties: any)
-   */
-  public setSuperProperties: ReplaySubject<any> = new ReplaySubject(10);
-
-  /*
-    @Param: (properties: any)
-   */
-  public setSuperPropertiesOnce: ReplaySubject<any> = new ReplaySubject(10);
-
-  /*
-    @Param: (properties: any)
-   */
-  public userTimings: ReplaySubject<any> = new ReplaySubject(10);
+  pageTrack = new ReplaySubject<{ path?: string, location?: Location}>(10);
+  eventTrack = new ReplaySubject<{action: string} | any>(10);
+  exceptionTrack = new ReplaySubject<any>(10);
+  setAlias = new ReplaySubject<string>(10);
+  setUsername = new ReplaySubject<{userId: string | number} | string>(10);
+  setUserProperties = new ReplaySubject<any>(10);
+  setUserPropertiesOnce = new ReplaySubject<any>(10);
+  setSuperProperties = new ReplaySubject<any>(10);
+  setSuperPropertiesOnce = new ReplaySubject<any>(10);
+  userTimings = new ReplaySubject<any>(10);
 
   constructor(location: Location, router: Router) {
     this.trackLocation(location, router);
   }
 
   trackLocation(location: Location, router: Router) {
-      filter.call(router.events, event => event instanceof NavigationEnd)
-      .subscribe((event: NavigationEnd) => {
-        if (!this.settings.developerMode) {
-          this.trackUrlChange(event.urlAfterRedirects, location);
-        }
-      });
+    router.events.pipe(
+      filter(event => event instanceof NavigationEnd),
+    ).subscribe((event: NavigationEnd) => {
+      if (!this.settings.developerMode) {
+        this.trackUrlChange(event.urlAfterRedirects, location);
+      }
+    });
   }
 
   virtualPageviews(value: boolean) {
@@ -96,13 +58,14 @@ export class Angulartics2 {
   }
 
   protected trackUrlChange(url: string, location: Location) {
-    if (!this.settings.developerMode) {
-      if (this.settings.pageTracking.autoTrackVirtualPages && !this.matchesExcludedRoute(url)) {
-        this.pageTrack.next({
-          path: this.settings.pageTracking.basePath.length ? this.settings.pageTracking.basePath + url : location.prepareExternalUrl(url),
-          location: location
-        });
-      }
+    if (this.settings.developerMode === true) {
+      return;
+    }
+    if (this.settings.pageTracking.autoTrackVirtualPages && !this.matchesExcludedRoute(url)) {
+      this.pageTrack.next({
+        path: this.settings.pageTracking.basePath.length ? this.settings.pageTracking.basePath + url : location.prepareExternalUrl(url),
+        location: location
+      });
     }
   }
 

--- a/src/lib/core/package.json
+++ b/src/lib/core/package.json
@@ -36,14 +36,9 @@
     "inspectlet"
   ],
   "peerDependencies": {
-    "@angular/animations": "^4.4.3",
-    "@angular/common": "^4.4.3",
-    "@angular/compiler": "^4.4.3",
-    "@angular/core": "^4.4.3",
-    "@angular/platform-browser": "^4.4.3",
-    "@angular/platform-browser-dynamic": "^4.4.3",
-    "@angular/router": "^4.4.3",
-    "rxjs": "^5.4.3",
-    "zone.js": "^0.8.17"
+    "@angular/common": "^4.4.0",
+    "@angular/core": "^4.4.0",
+    "@angular/router": "^4.4.0",
+    "rxjs": "^5.5.0"
   }
 }

--- a/src/lib/providers/appinsights/angulartics2-appinsights.ts
+++ b/src/lib/providers/appinsights/angulartics2-appinsights.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Router, NavigationEnd, NavigationStart, NavigationError } from '@angular/router';
-
-import { filter } from 'rxjs/operator/filter';
+import { filter } from 'rxjs/operators';
 
 import { Angulartics2 } from 'angulartics2';
 
@@ -38,14 +37,15 @@ export class Angulartics2AppInsights {
 
         this.angulartics2.setUserProperties.subscribe((x: any) => this.setUserProperties(x));
 
-        filter.call(this.router.events, event => event instanceof NavigationStart)
-            .subscribe(event => this.startTimer());
+        this.router.events.pipe(
+          filter(event => event instanceof NavigationStart),
+        ).subscribe(event => this.startTimer());
 
-        filter.call(this.router.events, event =>
-                (event instanceof NavigationError) ||
-                (event instanceof NavigationEnd)
-            )
-            .subscribe(error => this.stopTimer());
+        this.router.events.pipe(
+          filter(event => (event instanceof NavigationError) ||
+            (event instanceof NavigationEnd)
+          ),
+        ).subscribe(error => this.stopTimer());
     }
 
     startTimer() {

--- a/src/lib/providers/piwik/angulartics2-piwik.ts
+++ b/src/lib/providers/piwik/angulartics2-piwik.ts
@@ -39,7 +39,7 @@ export class Angulartics2Piwik {
   eventTrack(action: string, properties: any) {
     try {
       if (properties.value) {
-        var parsed = parseInt(properties.value, 10);
+        const parsed = parseInt(properties.value, 10);
         properties.value = isNaN(parsed) ? 0 : parsed;
       }
       _paq.push(['trackEvent', properties.category, action, properties.label, properties.value]);


### PR DESCRIPTION
This brings rxjs minimum version to ^5.5.0

More information on why lettable operators https://github.com/ReactiveX/rxjs/blob/6dc1b807fe0c60314cbf008655ce395bc2d6ed9b/doc/lettable-operators.md

I've added types to the ReplaySubjects. Already seeing some get a bit confusing without type strictness.
```ts
setUsername = new ReplaySubject<{userId: string | number} | string>(10);
```