### PR TITLE
feat(core): Added option to clear ids from url

### DIFF
--- a/src/core/angulartics2.spec.ts
+++ b/src/core/angulartics2.spec.ts
@@ -70,6 +70,13 @@ describe('angulartics2', () => {
           expect(angulartics2.settings.pageTracking.excludedRoutes).toEqual(['/abc/def', /\/[0-9]+/]);
     }));
 
+    it('should configure cleaning of ids',
+      inject([Angulartics2],
+        (angulartics2: Angulartics2) => {
+          angulartics2.clearIds(true);
+          expect(angulartics2.settings.pageTracking.clearIds).toBe(true);
+    }));
+
     it('should configure developer mode',
       fakeAsync(inject([Router, Location, Angulartics2],
          (router: Router, location: Location, angulartics2: Angulartics2) => {
@@ -211,6 +218,53 @@ describe('angulartics2', () => {
 
   });
 
+  describe('clearIds', function() {
+    var EventSpy: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule.withRoutes(RoutesConfig),
+          TestModule
+        ],
+        providers: [
+          { provide: Location, useClass: SpyLocation },
+          Angulartics2
+        ]
+      });
+
+      EventSpy = jasmine.createSpy('EventSpy');
+    })
+
+    it('should not clear ids by default',
+      inject([Angulartics2],
+        (angulartics2: Angulartics2) => {
+          expect(angulartics2.settings.pageTracking.clearIds).toBe(false);
+      }));
+
+    it('should not change url if clearIds is false',
+      fakeAsync(inject([Router, Location, Angulartics2],
+         (router: Router, location: Location, angulartics2: Angulartics2) => {
+          fixture = createRootWithRouter(router, RootCmp);
+          angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
+          angulartics2.settings.pageTracking.clearIds = false;
+          (<SpyLocation>location).simulateUrlPop('/sections/123/pages/456');
+          advance(fixture);
+          expect(EventSpy).toHaveBeenCalledWith({ path: '/sections/123/pages/456', location: location });
+      })));
+
+    it('should remove ids from url if clearIds is true',
+      fakeAsync(inject([Router, Location, Angulartics2],
+        (router: Router, location: Location, angulartics2: Angulartics2) => {
+        fixture = createRootWithRouter(router, RootCmp);
+        angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
+        angulartics2.settings.pageTracking.clearIds = true;
+        (<SpyLocation>location).simulateUrlPop('/sections/123/pages/456');
+        advance(fixture);
+        expect(EventSpy).toHaveBeenCalledWith({ path: '/sections/pages', location: location });
+      })));
+  });
+
   describe('EventEmiters', function() {
     var EventSpy: any;
 
@@ -254,7 +308,7 @@ describe('angulartics2', () => {
           advance(fixture);
 
           angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
-          
+
           expect(EventSpy).toHaveBeenCalledWith({ path: '/abc', location: location });
           expect(EventSpy).toHaveBeenCalledWith({ path: '/def', location: location });
           expect(EventSpy).toHaveBeenCalledWith({ path: '/ghi', location: location });

--- a/src/core/angulartics2.ts
+++ b/src/core/angulartics2.ts
@@ -10,7 +10,8 @@ export class Angulartics2 {
     pageTracking: {
       autoTrackVirtualPages: true,
       basePath: '',
-      excludedRoutes: []
+      excludedRoutes: [],
+      clearIds: false
     },
     eventTracking: {},
     developerMode: false
@@ -92,15 +93,19 @@ export class Angulartics2 {
   withBase(value: string) {
     this.settings.pageTracking.basePath = (value);
   }
+  clearIds(value: boolean) {
+    this.settings.pageTracking.clearIds = value;
+  }
   developerMode(value: boolean) {
     this.settings.developerMode = value;
   }
-  
+
   protected trackUrlChange(url: string, location: Location) {
     if (!this.settings.developerMode) {
       if (this.settings.pageTracking.autoTrackVirtualPages && !this.matchesExcludedRoute(url)) {
+        const clearedUrl = this.clearUrl(url);
         this.pageTrack.next({
-          path: this.settings.pageTracking.basePath.length ? this.settings.pageTracking.basePath + url : location.prepareExternalUrl(url),
+          path: this.settings.pageTracking.basePath.length ? this.settings.pageTracking.basePath + clearedUrl : location.prepareExternalUrl(clearedUrl),
           location: location
         });
       }
@@ -114,5 +119,15 @@ export class Angulartics2 {
       }
     }
     return false;
+  }
+
+  protected clearUrl(url: string): string {
+    if (this.settings.pageTracking.clearIds) {
+      return url
+        .split('/')
+        .filter(part => !part.match(/\d+/))
+        .join('/')
+    }
+    return url;
   }
 }


### PR DESCRIPTION
Added an option that clears all numeric ids from the route to be able to reliably track urls with
changing ids.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
URLs from page tracking can now be cleared of included IDs, which can intercept proper tracking on applications like a control panel in which every user has different ids in his url.


* **What is the current behavior?** (You can also link to an open issue here)
All URLs are being being tracked as they are. This can become an issue if every user has, for example, their own project, which results in URLs like `/project/12981/feature` with a different number for every user, which is being documented as a different pages.


* **What is the new behavior (if this is a feature change)?**
If the setting is set to `true`, numeric IDs are being removed from URLs. This would change `/project/12981/feature` to `/project/feature`.


* **Other information**:
