### PR TITLE
feat(provider) GTM - add custom tag ability

### DIFF
--- a/src/providers/gtm/angulartics2-gtm.spec.ts
+++ b/src/providers/gtm/angulartics2-gtm.spec.ts
@@ -41,9 +41,9 @@ describe('Angulartics2GoogleTagManager', () => {
     fakeAsync(inject([Angulartics2, Angulartics2GoogleTagManager],
         (angulartics2: Angulartics2, angulartics2GoogleTagManager: Angulartics2GoogleTagManager) => {
           fixture = createRoot(RootCmp);
-          angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
+          angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat', gtmCustom: { customKey: 'customValue' } } });
           advance(fixture);
-          expect(dataLayer).toContain({ event: 'interaction', target: 'cat', action: 'do', label: undefined, value: undefined, interactionType: undefined, userId: null });
+          expect(dataLayer).toContain({ event: 'interaction', target: 'cat', action: 'do', customKey: 'customValue', label: undefined, value: undefined, interactionType: undefined, userId: null });
       })));
 
   it('should track exceptions',

--- a/src/providers/gtm/angulartics2-gtm.ts
+++ b/src/providers/gtm/angulartics2-gtm.ts
@@ -62,7 +62,8 @@ export class Angulartics2GoogleTagManager {
         label: properties.label,
         value: properties.value,
         interactionType: properties.noninteraction,
-        userId: this.angulartics2.settings.gtm.userId
+        userId: this.angulartics2.settings.gtm.userId,
+        ...properties.gtmCustom
       });
     }
   }


### PR DESCRIPTION
New feature - allow custom tags as part of the GTM provider. New gtmCustom property.

closes https://github.com/angulartics/angulartics2/issues/162

