### PR TITLE
feat(core): allow settings from forRoot

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -101,6 +101,12 @@ function generateBundle(input, file, name, format) {
   return rollup({
     input,
     external: Object.keys(GLOBALS),
+    onwarn(warning) {
+      if (warning.code === 'THIS_IS_UNDEFINED') {
+        return;
+      }
+      console.log(warning.message);
+    },
     file,
     plugins,
   }).then(bundle => {

--- a/src/lib/core/angulartics2-config.ts
+++ b/src/lib/core/angulartics2-config.ts
@@ -1,15 +1,10 @@
 import { AppInsightsDefaults } from '../providers/appinsights';
-export interface PageTrackingSettings {
-  autoTrackVirtualPages: boolean;
-  basePath: string;
-  excludedRoutes: (string | RegExp)[];
-}
 
 export interface GoogleAnalyticsSettings {
-  /* array of additional account names (only works for analyticsjs) */
+  /** array of additional account names (only works for analyticsjs) */
   additionalAccountNames: string[];
   userId: any;
-  /* see https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport */
+  /** see https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport */
   transport: string;
 }
 
@@ -19,6 +14,12 @@ export interface AppInsightsSettings {
 
 export interface GoogleTagManagerSettings {
   userId: any;
+}
+
+export interface PageTrackingSettings {
+  autoTrackVirtualPages: boolean;
+  basePath: string;
+  excludedRoutes: (string | RegExp)[];
 }
 
 export interface Angulartics2Settings {

--- a/src/lib/core/angulartics2-config.ts
+++ b/src/lib/core/angulartics2-config.ts
@@ -1,0 +1,44 @@
+import { AppInsightsDefaults } from '../providers/appinsights';
+export interface PageTrackingSettings {
+  autoTrackVirtualPages: boolean;
+  basePath: string;
+  excludedRoutes: (string | RegExp)[];
+}
+
+export interface GoogleAnalyticsSettings {
+  /* array of additional account names (only works for analyticsjs) */
+  additionalAccountNames: string[];
+  userId: any;
+  /* see https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport */
+  transport: string;
+}
+
+export interface AppInsightsSettings {
+  userId: any;
+}
+
+export interface GoogleTagManagerSettings {
+  userId: any;
+}
+
+export interface Angulartics2Settings {
+  pageTracking: Partial<PageTrackingSettings>;
+  eventTracking: any;
+  developerMode: boolean;
+  ga: Partial<GoogleAnalyticsSettings>;
+  appInsights: Partial<AppInsightsSettings>;
+  gtm: Partial<GoogleTagManagerSettings>;
+}
+
+export class DefaultConfig implements Angulartics2Settings {
+  pageTracking = {
+    autoTrackVirtualPages: true,
+    basePath: '',
+    excludedRoutes: [],
+  };
+  eventTracking = {};
+  developerMode = false;
+  ga = {};
+  appInsights = {};
+  gtm = {};
+}

--- a/src/lib/core/angulartics2-config.ts
+++ b/src/lib/core/angulartics2-config.ts
@@ -1,5 +1,3 @@
-import { AppInsightsDefaults } from '../providers/appinsights';
-
 export interface GoogleAnalyticsSettings {
   /** array of additional account names (only works for analyticsjs) */
   additionalAccountNames: string[];

--- a/src/lib/core/angulartics2-token.ts
+++ b/src/lib/core/angulartics2-token.ts
@@ -1,0 +1,9 @@
+import { InjectionToken } from '@angular/core';
+import { Angulartics2Settings } from './angulartics2-config';
+
+export interface Angulartics2Token {
+  providers: any[];
+  settings: Partial<Angulartics2Settings>;
+}
+
+export const ANGULARTICS2_TOKEN = new InjectionToken<Angulartics2Token>('ANGULARTICS2');

--- a/src/lib/core/angulartics2-token.ts
+++ b/src/lib/core/angulartics2-token.ts
@@ -1,4 +1,5 @@
 import { InjectionToken } from '@angular/core';
+
 import { Angulartics2Settings } from './angulartics2-config';
 
 export interface Angulartics2Token {

--- a/src/lib/core/angulartics2.module.ts
+++ b/src/lib/core/angulartics2.module.ts
@@ -3,35 +3,35 @@ import {
   ModuleWithProviders,
   Optional,
   SkipSelf,
-  InjectionToken,
 } from '@angular/core';
 
 import { Angulartics2 } from './angulartics2';
-import { Angulartics2On } from './angulartics2On'
-
-
-export const ANGULARTICS2_TOKEN = new InjectionToken<any[]>('ANGULARTICS2');
+import { Angulartics2On } from './angulartics2On';
+import { ANGULARTICS2_TOKEN } from './angulartics2-token';
+import { Angulartics2Settings } from './angulartics2-config';
 
 
 @NgModule({
-  declarations: [ Angulartics2On ],
-  exports: [ Angulartics2On ],
+  declarations: [Angulartics2On],
+  exports: [Angulartics2On],
 })
 export class Angulartics2Module {
   constructor(@Optional() @SkipSelf() parentModule: Angulartics2Module) {
     if (parentModule) {
-      throw new Error('Angulartics2Module.forRoot() called twice. Lazy loaded modules should use Angulartics2Module instead.');
+      throw new Error(
+        'Angulartics2Module.forRoot() called twice. Lazy loaded modules should use Angulartics2Module instead.',
+      );
     }
   }
 
-  static forRoot(providers: any[]): ModuleWithProviders {
+  static forRoot(providers: any[] = [], settings: Partial<Angulartics2Settings> = {}): ModuleWithProviders {
     return {
       ngModule: Angulartics2Module,
       providers: [
-        { provide: ANGULARTICS2_TOKEN, useValue: providers },
+        { provide: ANGULARTICS2_TOKEN, useValue: { providers, settings } },
         Angulartics2,
         ...providers,
-      ]
-    }
+      ],
+    };
   }
 }

--- a/src/lib/core/angulartics2.spec.ts
+++ b/src/lib/core/angulartics2.spec.ts
@@ -10,8 +10,7 @@ import { Angulartics2 } from 'angulartics2';
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
 
 describe('angulartics2', () => {
-
-  var fixture: ComponentFixture<any>;
+  let fixture: ComponentFixture<any>;
 
   it('is defined', () => {
     expect(Angulartics2).toBeDefined();
@@ -26,8 +25,8 @@ describe('angulartics2', () => {
           TestModule
         ],
         providers: [
-          Angulartics2
-        ]
+          Angulartics2,
+        ],
       });
     });
 
@@ -56,25 +55,11 @@ describe('angulartics2', () => {
       EventSpy = jasmine.createSpy('EventSpy');
     });
 
-    it('should configure virtualPageviews',
-      inject([Angulartics2],
-        (angulartics2: Angulartics2) => {
-          angulartics2.virtualPageviews(false);
-          expect(angulartics2.settings.pageTracking.autoTrackVirtualPages).toBe(false);
-    }));
-
-    it('should configure excluded routes',
-      inject([Angulartics2],
-        (angulartics2: Angulartics2) => {
-          angulartics2.excludeRoutes(['/abc/def', /\/[0-9]+/]);
-          expect(angulartics2.settings.pageTracking.excludedRoutes).toEqual(['/abc/def', /\/[0-9]+/]);
-    }));
-
     it('should configure developer mode',
       fakeAsync(inject([Router, Location, Angulartics2],
          (router: Router, location: Location, angulartics2: Angulartics2) => {
           fixture = createRootWithRouter(router, RootCmp);
-          angulartics2.developerMode(true);
+          angulartics2.settings.developerMode = true;
           angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
           (<SpyLocation>location).simulateUrlPop('/abc');
           advance(fixture);

--- a/src/lib/core/angulartics2.spec.ts
+++ b/src/lib/core/angulartics2.spec.ts
@@ -55,6 +55,20 @@ describe('angulartics2', () => {
       EventSpy = jasmine.createSpy('EventSpy');
     });
 
+    it('should configure virtualPageviews',
+      inject([Angulartics2],
+        (angulartics2: Angulartics2) => {
+          angulartics2.virtualPageviews(false);
+          expect(angulartics2.settings.pageTracking.autoTrackVirtualPages).toBe(false);
+    }));
+
+    it('should configure excluded routes',
+      inject([Angulartics2],
+        (angulartics2: Angulartics2) => {
+          angulartics2.excludeRoutes(['/abc/def', /\/[0-9]+/]);
+          expect(angulartics2.settings.pageTracking.excludedRoutes).toEqual(['/abc/def', /\/[0-9]+/]);
+    }));
+
     it('should configure developer mode',
       fakeAsync(inject([Router, Location, Angulartics2],
          (router: Router, location: Location, angulartics2: Angulartics2) => {

--- a/src/lib/core/angulartics2.ts
+++ b/src/lib/core/angulartics2.ts
@@ -30,14 +30,24 @@ export class Angulartics2 {
   }
 
   trackLocation(location: Location, router: Router) {
-    router.events
-      .pipe(
-        filter(event => event instanceof NavigationEnd),
-        filter(() => !this.settings.developerMode),
-      )
-      .subscribe((event: NavigationEnd) =>
-        this.trackUrlChange(event.urlAfterRedirects, location),
-      );
+    router.events.pipe(
+      filter(event => event instanceof NavigationEnd),
+      filter(() => !this.settings.developerMode),
+    ).subscribe((event: NavigationEnd) =>
+      this.trackUrlChange(event.urlAfterRedirects, location),
+    );
+  }
+  /** @deprecated */
+  virtualPageviews(value: boolean) {
+    this.settings.pageTracking.autoTrackVirtualPages = value;
+  }
+  /** @deprecated */
+  excludeRoutes(routes: Array<string|RegExp>) {
+    this.settings.pageTracking.excludedRoutes = routes;
+  }
+  /** @deprecated */
+  withBase(value: string) {
+    this.settings.pageTracking.basePath = value;
   }
 
   protected trackUrlChange(url: string, location: Location) {

--- a/src/lib/core/angulartics2.ts
+++ b/src/lib/core/angulartics2.ts
@@ -1,76 +1,60 @@
 import { Location } from '@angular/common';
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 
+import { Angulartics2Settings, DefaultConfig } from './angulartics2-config';
+import { ANGULARTICS2_TOKEN, Angulartics2Token } from './angulartics2-token';
+
 @Injectable()
 export class Angulartics2 {
-  public settings: any = {
-    pageTracking: {
-      autoTrackVirtualPages: true,
-      basePath: '',
-      excludedRoutes: [],
-    },
-    eventTracking: {},
-    developerMode: false,
-  };
+  settings: Angulartics2Settings;
 
-  pageTrack = new ReplaySubject<{ path?: string, location?: Location}>(10);
-  eventTrack = new ReplaySubject<{action: string} | any>(10);
+  pageTrack = new ReplaySubject<{ path?: string; location?: Location }>(10);
+  eventTrack = new ReplaySubject<{ action: string } | any>(10);
   exceptionTrack = new ReplaySubject<any>(10);
   setAlias = new ReplaySubject<string>(10);
-  setUsername = new ReplaySubject<{userId: string | number} | string>(10);
+  setUsername = new ReplaySubject<{ userId: string | number } | string>(10);
   setUserProperties = new ReplaySubject<any>(10);
   setUserPropertiesOnce = new ReplaySubject<any>(10);
   setSuperProperties = new ReplaySubject<any>(10);
   setSuperPropertiesOnce = new ReplaySubject<any>(10);
   userTimings = new ReplaySubject<any>(10);
 
-  constructor(location: Location, router: Router) {
+  constructor(location: Location, router: Router, @Inject(ANGULARTICS2_TOKEN) setup: Angulartics2Token) {
+    const defaultConfig = new DefaultConfig;
+    this.settings = { ...defaultConfig, ...setup.settings };
+    this.settings.pageTracking = { ...defaultConfig.pageTracking, ...setup.settings.pageTracking };
     this.trackLocation(location, router);
   }
 
   trackLocation(location: Location, router: Router) {
-    router.events.pipe(
-      filter(event => event instanceof NavigationEnd),
-      filter(() => !this.settings.developerMode),
-    ).subscribe(
-      (event: NavigationEnd) => this.trackUrlChange(event.urlAfterRedirects, location),
-    );
-  }
-
-  virtualPageviews(value: boolean) {
-    this.settings.pageTracking.autoTrackVirtualPages = value;
-  }
-  excludeRoutes(routes: Array<string|RegExp>) {
-    this.settings.pageTracking.excludedRoutes = routes;
-  }
-  firstPageview(value: boolean) {
-    this.settings.pageTracking.autoTrackFirstPage = value;
-  }
-  withBase(value: string) {
-    this.settings.pageTracking.basePath = (value);
-  }
-  developerMode(value: boolean) {
-    this.settings.developerMode = value;
+    router.events
+      .pipe(
+        filter(event => event instanceof NavigationEnd),
+        filter(() => !this.settings.developerMode),
+      )
+      .subscribe((event: NavigationEnd) =>
+        this.trackUrlChange(event.urlAfterRedirects, location),
+      );
   }
 
   protected trackUrlChange(url: string, location: Location) {
-    if (this.settings.developerMode === true) {
-      return;
-    }
     if (this.settings.pageTracking.autoTrackVirtualPages && !this.matchesExcludedRoute(url)) {
       this.pageTrack.next({
-        path: this.settings.pageTracking.basePath.length ? this.settings.pageTracking.basePath + url : location.prepareExternalUrl(url),
-        location: location
+        path: this.settings.pageTracking.basePath.length
+          ? this.settings.pageTracking.basePath + url
+          : location.prepareExternalUrl(url),
+        location: location,
       });
     }
   }
 
   protected matchesExcludedRoute(url: string): boolean {
     for (const excludedRoute of this.settings.pageTracking.excludedRoutes) {
-      if ((excludedRoute instanceof RegExp && excludedRoute.test(url)) || url.indexOf(excludedRoute) > -1) {
+      const matchesRegex = excludedRoute instanceof RegExp && excludedRoute.test(url);
+      if (matchesRegex || url.indexOf(<string>excludedRoute) !== -1) {
         return true;
       }
     }

--- a/src/lib/core/public_api.ts
+++ b/src/lib/core/public_api.ts
@@ -1,3 +1,4 @@
 export * from './angulartics2';
 export * from './angulartics2.module';
-// export * from './angulartics2.token';
+export * from './angulartics2-token';
+export * from './angulartics2-config';

--- a/src/lib/providers/adobeanalytics/angulartics2-adobeanalytics.ts
+++ b/src/lib/providers/adobeanalytics/angulartics2-adobeanalytics.ts
@@ -12,7 +12,6 @@ export class Angulartics2AdobeAnalytics {
     private angulartics2: Angulartics2,
     private location: Location
   ) {
-    this.angulartics2.settings.pageTracking.trackRelativePath = true;
 
     this.angulartics2.pageTrack.subscribe((x: any) => this.pageTrack(x.path));
 

--- a/src/lib/providers/appinsights/angulartics2-appinsights.ts
+++ b/src/lib/providers/appinsights/angulartics2-appinsights.ts
@@ -1,64 +1,73 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { Router, NavigationEnd, NavigationStart, NavigationError } from '@angular/router';
+import {
+  NavigationEnd,
+  NavigationError,
+  NavigationStart,
+  Router,
+} from '@angular/router';
 import { filter } from 'rxjs/operators';
 
-import { Angulartics2 } from 'angulartics2';
+import { Angulartics2, AppInsightsSettings } from 'angulartics2';
 
 declare const appInsights: Microsoft.ApplicationInsights.IAppInsights;
 
+export class AppInsightsDefaults implements AppInsightsSettings {
+  userId = null;
+}
+
 @Injectable()
 export class Angulartics2AppInsights {
-    loadStartTime: number = null;
-    loadTime: number = null;
+  loadStartTime: number = null;
+  loadTime: number = null;
 
-    metrics: any = null;
-    dimensions: any = null;
-    measurements: any = null;
+  metrics: any = null;
+  dimensions: any = null;
+  measurements: any = null;
 
-    constructor(private angulartics2: Angulartics2,
-                private title: Title,
-                private router: Router) {
-        if (typeof (appInsights) === 'undefined') {
-            console.warn('appInsights not found');
-        }
-
-        this.angulartics2.settings.appInsights = {
-            userId: null
-        };
-
-        this.angulartics2.pageTrack.subscribe((x: any) => this.pageTrack(x.path));
-
-        this.angulartics2.eventTrack.subscribe((x: any) => this.eventTrack(x.action, x.properties));
-
-        this.angulartics2.exceptionTrack.subscribe((x: any) => this.exceptionTrack(x));
-
-        this.angulartics2.setUsername.subscribe((x: string) => this.setUsername(x));
-
-        this.angulartics2.setUserProperties.subscribe((x: any) => this.setUserProperties(x));
-
-        this.router.events.pipe(
-          filter(event => event instanceof NavigationStart),
-        ).subscribe(event => this.startTimer());
-
-        this.router.events.pipe(
-          filter(event => (event instanceof NavigationError) ||
-            (event instanceof NavigationEnd)
-          ),
-        ).subscribe(error => this.stopTimer());
+  constructor(
+    private angulartics2: Angulartics2,
+    private title: Title,
+    private router: Router,
+  ) {
+    if (typeof appInsights === 'undefined') {
+      console.warn('appInsights not found');
     }
 
-    startTimer() {
-        this.loadStartTime = Date.now();
-        this.loadTime = null;
-    }
+    const defaults = new AppInsightsDefaults;
+    // Set the default settings for this module
+    this.angulartics2.settings.appInsights = { ...defaults, ...this.angulartics2.settings.appInsights };
 
-    stopTimer() {
-        this.loadTime = Date.now() - this.loadStartTime;
-        this.loadStartTime = null;
-    }
+    this.angulartics2.pageTrack.subscribe((x: any) => this.pageTrack(x.path));
 
-    /**
+    this.angulartics2.eventTrack.subscribe((x: any) => this.eventTrack(x.action, x.properties));
+
+    this.angulartics2.exceptionTrack.subscribe((x: any) => this.exceptionTrack(x));
+
+    this.angulartics2.setUsername.subscribe((x: string) => this.setUsername(x));
+
+    this.angulartics2.setUserProperties.subscribe((x: any) => this.setUserProperties(x));
+
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationStart))
+      .subscribe(event => this.startTimer());
+
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationError || event instanceof NavigationEnd))
+      .subscribe(error => this.stopTimer());
+  }
+
+  startTimer() {
+    this.loadStartTime = Date.now();
+    this.loadTime = null;
+  }
+
+  stopTimer() {
+    this.loadTime = Date.now() - this.loadStartTime;
+    this.loadStartTime = null;
+  }
+
+  /**
      * Page Track in Baidu Analytics
      * @name pageTrack
      *
@@ -67,17 +76,17 @@ export class Angulartics2AppInsights {
      * @link https://github.com/Microsoft/ApplicationInsights-JS/blob/master/API-reference.md#trackpageview
      *
      */
-    pageTrack(path: string) {
-        appInsights.trackPageView(
-            this.title.getTitle(),
-            path,
-            this.dimensions,
-            this.metrics,
-            this.loadTime
-        );
-    }
+  pageTrack(path: string) {
+    appInsights.trackPageView(
+      this.title.getTitle(),
+      path,
+      this.dimensions,
+      this.metrics,
+      this.loadTime,
+    );
+  }
 
-    /**
+  /**
      * Log a user action or other occurrence.
      * @param   name    A string to identify this event in the portal.
      *
@@ -85,11 +94,11 @@ export class Angulartics2AppInsights {
      *
      * @https://github.com/Microsoft/ApplicationInsights-JS/blob/master/API-reference.md#trackevent
      */
-    eventTrack(name: string, properties: any) {
-        appInsights.trackEvent(name, properties, this.measurements);
-    }
+  eventTrack(name: string, properties: any) {
+    appInsights.trackEvent(name, properties, this.measurements);
+  }
 
-    /**
+  /**
      * Exception Track Event in GA
      * @name exceptionTrack
      *
@@ -98,34 +107,34 @@ export class Angulartics2AppInsights {
      *
      * @link https://github.com/Microsoft/ApplicationInsights-JS/blob/master/API-reference.md#trackexception
      */
-    exceptionTrack(properties: any) {
-        let description = properties.event || properties.description || properties;
+  exceptionTrack(properties: any) {
+    let description = properties.event || properties.description || properties;
 
-        appInsights.trackException(description);
-    }
+    appInsights.trackException(description);
+  }
 
-    /**
+  /**
      *
      * @param userId
      *
      * @link https://github.com/Microsoft/ApplicationInsights-JS/blob/master/API-reference.md#setauthenticatedusercontext
      */
 
-    setUsername(userId: string) {
-        this.angulartics2.settings.appInsights.userId = userId;
-        appInsights.setAuthenticatedUserContext(userId);
+  setUsername(userId: string) {
+    this.angulartics2.settings.appInsights.userId = userId;
+    appInsights.setAuthenticatedUserContext(userId);
+  }
+
+  setUserProperties(properties: any) {
+    if (properties.userId) {
+      this.angulartics2.settings.appInsights.userId = properties.userId;
     }
 
-    setUserProperties(properties: any) {
-        if (properties.userId) {
-            this.angulartics2.settings.appInsights.userId = properties.userId;
-        }
-
-        if (properties.accountId) {
-            appInsights.setAuthenticatedUserContext(
-                this.angulartics2.settings.appInsights.userId,
-                properties.accountId
-            );
-        }
+    if (properties.accountId) {
+      appInsights.setAuthenticatedUserContext(
+        this.angulartics2.settings.appInsights.userId,
+        properties.accountId,
+      );
     }
+  }
 }

--- a/src/lib/providers/facebook/angulartics2-facebook.ts
+++ b/src/lib/providers/facebook/angulartics2-facebook.ts
@@ -10,8 +10,6 @@ export class Angulartics2Facebook {
   constructor(
     private angulartics2: Angulartics2
   ) {
-    this.angulartics2.settings.pageTracking.trackRelativePath = true;
-
     this.angulartics2.eventTrack.subscribe((x: any) => this.eventTrack(x.action, x.properties));
   }
 

--- a/src/lib/providers/ga/angulartics2-ga.spec.ts
+++ b/src/lib/providers/ga/angulartics2-ga.spec.ts
@@ -25,7 +25,6 @@ describe('Angulartics2GoogleAnalytics', () => {
         Angulartics2GoogleAnalytics
       ]
     });
-
     window.ga = ga = jasmine.createSpy('ga');
     window._gaq = _gaq = [];
   });
@@ -47,16 +46,16 @@ describe('Angulartics2GoogleAnalytics', () => {
           advance(fixture);
           expect(ga).toHaveBeenCalledWith('send', 'event', { eventCategory: 'cat', eventAction: 'do', eventLabel: undefined, eventValue: undefined, nonInteraction: undefined, page: '/context.html', userId: null, hitCallback: undefined });
       })));
-       
+
   it('should track events with hitCallback',
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
         (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
           fixture = createRoot(RootCmp);
-          const callback = function() { };          
+          const callback = function() { };
           angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat', hitCallback: callback } });
           advance(fixture);
           expect(ga).toHaveBeenCalledWith('send', 'event', { eventCategory: 'cat', eventAction: 'do', eventLabel: undefined, eventValue: undefined, nonInteraction: undefined, page: '/context.html', userId: null, hitCallback: callback });
-      })));      
+      })));
 
   it('should track exceptions',
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],

--- a/src/lib/providers/gtm/angulartics2-gtm.ts
+++ b/src/lib/providers/gtm/angulartics2-gtm.ts
@@ -1,27 +1,26 @@
 import { Injectable } from '@angular/core';
 
-import { Angulartics2 } from 'angulartics2';
+import { Angulartics2, GoogleTagManagerSettings } from 'angulartics2';
 
 declare var dataLayer: any;
+
+export class GoogleTagManagerDefaults implements GoogleTagManagerSettings {
+  userId = null;
+}
 
 @Injectable()
 export class Angulartics2GoogleTagManager {
 
   constructor(
-    private angulartics2: Angulartics2
+    private angulartics2: Angulartics2,
   ) {
-
     // The dataLayer needs to be initialized
     if (typeof dataLayer !== 'undefined' && dataLayer) {
       dataLayer = (<any>window).dataLayer = (<any>window).dataLayer || [];
     }
-
-    this.angulartics2.settings.pageTracking.trackRelativePath = true;
-
+    const defaults = new GoogleTagManagerDefaults;
     // Set the default settings for this module
-    this.angulartics2.settings.gtm = {
-      userId: null
-    };
+    this.angulartics2.settings.gtm = { ...defaults, ...this.angulartics2.settings.gtm };
 
     this.angulartics2.pageTrack.subscribe((x: any) => this.pageTrack(x.path));
 


### PR DESCRIPTION
before settings could only be set after importing inside another service or component.

now settings can be set on app init with type checking.
```ts
Angulartics2Module.forRoot([Angulartics2GoogleAnalytics], { 
     developerMode: true,
     excludedRoutes: ['/abc'],
});
```
adds deprecated flags to the config setter functions like virtualPageviews as its pretty straight forward to set them using settings or the same way the rest the settings are done.