### PR TITLE
fix(core): remove module import protection so lazy modules import work

### DIFF
--- a/src/lib/core/angulartics2.module.ts
+++ b/src/lib/core/angulartics2.module.ts
@@ -1,8 +1,6 @@
 import {
   NgModule,
   ModuleWithProviders,
-  Optional,
-  SkipSelf,
   Provider,
 } from '@angular/core';
 
@@ -17,14 +15,6 @@ import { Angulartics2Settings } from './angulartics2-config';
   exports: [Angulartics2On],
 })
 export class Angulartics2Module {
-  constructor(@Optional() @SkipSelf() parentModule: Angulartics2Module) {
-    if (parentModule) {
-      throw new Error(
-        'Angulartics2Module.forRoot() called twice. Lazy loaded modules should use Angulartics2Module instead.',
-      );
-    }
-  }
-
   static forRoot(providers: Provider[], settings: Partial<Angulartics2Settings> = {}): ModuleWithProviders {
     return {
       ngModule: Angulartics2Module,


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Removes module import protection so lazy modules import work


* **What is the current behavior?** (You can also link to an open issue here)
There is no way you can use `Angulartics2On` directive in lazy modules


* **What is the new behavior (if this is a feature change)?**
It is expected to import `Angulartics2Module` in any lazy module, to use `Angulartics2On`


* **Other information**:
The way the import protection was implemented does not allow
the `Angulartics2Module` to be imported in lazy loaded modules,
however this is required in order to use `Angulartics2On` directive
in there.

To shortly disambiguate usage of `forRoot()` and similar protection:
 - Such protection is need mainly to not allow providers that are meant
 to be global singletons (in this case `Angulartics2` service
 and providers) to end up being instantiated in each module
 `Angulartics2Module` is imported. However the protection makes sense
 only if there is a module that has *only providers* and no directives
 or components and exported components and directives are in another not
 protected module.
 - Given the `forRoot()` is quite commonly used concept and the
 protection is holding off developers that have specific cases it is
 better to go without the protection and only with `forRoot()`

Summary:
 - `Angulartics2Module.forRoot()` is recommended to be placed only in
 the root AppModule, or in other places only if the developer knows
 what he is doing
 - `Angulartics2Module` can now be imported in any module, lazy or not
 that wants to use `Angulartics2On` directive
 - For ease of use `Angulartics2Module` can be re-exported
 @see https://angular.io/guide/ngmodule#re-exporting-other-modules

closes https://github.com/angulartics/angulartics2/issues/63