### PR TITLE
fix(providers): Don't throw if ga is not defined

### DIFF
--- a/src/lib/providers/ga/angulartics2-ga.ts
+++ b/src/lib/providers/ga/angulartics2-ga.ts
@@ -154,7 +154,7 @@ export class Angulartics2GoogleAnalytics {
       return;
     }
 
-    if (ga) {
+    if (typeof ga !== 'undefined') {
       ga('send', 'timing', properties);
     }
   }
@@ -168,7 +168,7 @@ export class Angulartics2GoogleAnalytics {
   }
 
   private setDimensionsAndMetrics(properties: any) {
-    if (!ga) {
+    if (typeof ga === 'undefined') {
       return;
     }
     // add custom dimensions and metrics


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Uses typeof checks everwhere (as used by eventTrack) to prevent 

```
ReferenceError: ga is not defined
    at Angulartics2GoogleAnalytics.setDimensionsAndMetrics (angulartics2-ga.js:163)
    at Angulartics2GoogleAnalytics.setUserProperties (angulartics2-ga.js:160)
```

for users with tracking blockers.


* **What is the current behavior?** (You can also link to an open issue here)
It throws an error if adblockers are used and the site uses setUserProperties.


* **What is the new behavior (if this is a feature change)?**
It doesn't throw.


* **Other information**:
I really like this module!