### PR TITLE
docs: Update component import in Getting Started for ga example

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,7 +11,7 @@ import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 })
 `;
 
-const importComponent = `import { Angulartics2GoogleAnalytics } from 'angulartics2';
+const importComponent = `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 
 @Component({
   selector: 'app',


### PR DESCRIPTION
The documentation is missing `/ga` for the "Import all providers in
root component" section of https://angulartics.github.io/angulartics2/#getting-started

* **What kind of change does this PR introduce?**

Update to the documentation/ghpages website.

* **What is the current behavior?** (You can also link to an open issue here)

![image](https://user-images.githubusercontent.com/296333/32873758-88926bb4-cad9-11e7-9422-2147d94b18b9.png)


* **What is the new behavior (if this is a feature change)?**

Line is updated to `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';`


* **Other information**:
