### PR TITLE
fix(providers): GA optimized reset of custom dimensions and metrics

### DIFF
--- a/src/lib/providers/ga/angulartics2-ga.ts
+++ b/src/lib/providers/ga/angulartics2-ga.ts
@@ -14,6 +14,7 @@ export class GoogleAnalyticsDefaults implements GoogleAnalyticsSettings {
 
 @Injectable()
 export class Angulartics2GoogleAnalytics {
+  dimensionsAndMetrics = [];
 
   constructor(
     private angulartics2: Angulartics2,
@@ -171,18 +172,20 @@ export class Angulartics2GoogleAnalytics {
     if (!ga) {
       return;
     }
+    // clean previously used dimensions and metrics that will not be overriden
+    this.dimensionsAndMetrics.forEach((elem) => {
+      if (!properties.hasOwnProperty(elem)) {
+        ga('set', elem, undefined);
+      }
+    });
+    this.dimensionsAndMetrics = [];
+
     // add custom dimensions and metrics
-    for (let idx = 1; idx <= 200; idx++) {
-      if (properties['dimension' + idx.toString()]) {
-        ga('set', 'dimension' + idx.toString(), properties['dimension' + idx.toString()]);
-      } else {
-        ga('set', 'dimension' + idx.toString(), undefined);
+    Object.keys(properties).forEach((key) => {
+      if (key.lastIndexOf('dimension', 0) === 0 || key.lastIndexOf('metric', 0) === 0) {
+        ga('set', key, properties[key]);
+        this.dimensionsAndMetrics.push(key);
       }
-      if (properties['metric' + idx.toString()]) {
-        ga('set', 'metric' + idx.toString(), properties['metric' + idx.toString()]);
-      } else {
-        ga('set', 'metric' + idx.toString(), undefined);
-      }
-    }
+    });
   }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
It optimizes the set and reset of custom dimensions and metrics in google analytics


* **What is the current behavior?** (You can also link to an open issue here)
The code loops from 0 to 200 and sets all unused dimensions to undefined, same thing with metrics.  I assume this is to reset custom dimensions from a previous call.
This generates ~400 calls to ga('set', 'dimension-n', undefined) per each event that you want to track.
This takes between 2ms and 6 ms per event in a highspeed conection, if you want to track several events under a mobile connection it gets really slow.


* **What is the new behavior (if this is a feature change)?**
Instead of the looping from 0 to 200, the code caches setting custom dimensions and metrics and on next call unsets only the ones that will not be overriden with new values. This drastically speeds things up taking it from ~4ms to ~0.13 ms


* **Other information**:
