### PR TITLE
fix(providers): Change accessibility of angulartics2 field in Angulartics2GoogleTagManager provider

### DIFF
--- a/src/lib/providers/gtm/angulartics2-gtm.ts
+++ b/src/lib/providers/gtm/angulartics2-gtm.ts
@@ -12,7 +12,7 @@ export class GoogleTagManagerDefaults implements GoogleTagManagerSettings {
 export class Angulartics2GoogleTagManager {
 
   constructor(
-    private angulartics2: Angulartics2,
+    protected angulartics2: Angulartics2,
   ) {
     // The dataLayer needs to be initialized
     if (typeof dataLayer !== 'undefined' && dataLayer) {


### PR DESCRIPTION
Allows to extend Angulartics2GoogleTagManager class and use this.angulartics2 within overriden methods.

* **What kind of change does this PR introduce?**
Changing accessibility of `angulartics2` field in Angulartics2GoogleTagManager 

* **What is the current behavior?**
When extending `Angulartics2GoogleTagManager` and overriding for instance the `pageTrack(path: string)` method, you're not able to use this.angulartics2 field, as it is private in the super class.

* **What is the new behavior (if this is a feature change)?**
When extending the Angulartics2GoogleTagManager class, you're able to access the injected angulartics field.

* **Other information**:
Other providers have the same issue. If you agree and it makes sense to change those as well, I can change it in those providers too (maybe in this pr?).