### PR TITLE
Add dimensions and metrics to all account names

### DIFF
--- a/src/lib/providers/ga/angulartics2-ga.spec.ts
+++ b/src/lib/providers/ga/angulartics2-ga.spec.ts
@@ -75,7 +75,7 @@ describe('Angulartics2GoogleAnalytics', () => {
           expect(angulartics2.settings.ga.userId).toBe('testuser');
       })));
 
-  it('should set user porperties',
+  it('should set user properties',
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
         (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
           fixture = createRoot(RootCmp);
@@ -86,6 +86,24 @@ describe('Angulartics2GoogleAnalytics', () => {
           advance(fixture);
           expect(ga).toHaveBeenCalledWith('set', 'metric1', 'test');
       })));
+
+    it('should set user properties on all account names',
+      fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
+          (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
+            fixture = createRoot(RootCmp);
+            angulartics2.settings.ga.additionalAccountNames.push('additionalAccountName');
+            angulartics2.settings.ga.additionalAccountNames.push('additionalAccountNameTwo');
+            angulartics2.setUserProperties.next({ dimension1: 'test' });
+            advance(fixture);
+            expect(ga).toHaveBeenCalledWith('set', 'dimension1', 'test');
+            expect(ga).toHaveBeenCalledWith('additionalAccountName.set', 'dimension1', 'test');
+            expect(ga).toHaveBeenCalledWith('additionalAccountNameTwo.set', 'dimension1', 'test');
+            angulartics2.setUserProperties.next({ metric1: 'test' });
+            advance(fixture);
+            expect(ga).toHaveBeenCalledWith('set', 'metric1', 'test');
+            expect(ga).toHaveBeenCalledWith('additionalAccountName.set', 'metric1', 'test');
+            expect(ga).toHaveBeenCalledWith('additionalAccountNameTwo.set', 'metric1', 'test');
+        })));
 
   it('should track user timings',
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],

--- a/src/lib/providers/ga/angulartics2-ga.ts
+++ b/src/lib/providers/ga/angulartics2-ga.ts
@@ -176,6 +176,10 @@ export class Angulartics2GoogleAnalytics {
     this.dimensionsAndMetrics.forEach((elem) => {
       if (!properties.hasOwnProperty(elem)) {
         ga('set', elem, undefined);
+
+        this.angulartics2.settings.ga.additionalAccountNames.forEach((accountName: string) => {
+          ga(`${accountName}.set`, elem, undefined);
+        });
       }
     });
     this.dimensionsAndMetrics = [];
@@ -184,6 +188,10 @@ export class Angulartics2GoogleAnalytics {
     Object.keys(properties).forEach((key) => {
       if (key.lastIndexOf('dimension', 0) === 0 || key.lastIndexOf('metric', 0) === 0) {
         ga('set', key, properties[key]);
+
+        this.angulartics2.settings.ga.additionalAccountNames.forEach((accountName: string) => {
+          ga(`${accountName}.set`, key, properties[key]);
+        });
         this.dimensionsAndMetrics.push(key);
       }
     });


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Similar to tracking pageviews and events, custom dimensions and metrics are applied to all additional account names.


* **What is the current behavior?** (You can also link to an open issue here)
The current behaviour only adds custom dimensions and metrics to the unnamed tracker. #119 


* **What is the new behavior (if this is a feature change)?**
Custom dimensions and metrics are added to all account names supplied by the user.


* **Other information**:
I cannot run the build locally, assumably a Windows issue. However I have been able to run the tests and see them pass.
