### PR TITLE
feat(core): clearUrl - New RegExp for url clearing, new configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,32 @@ Angulartics2Module.forRoot([providers], {
   }
 }),
 ````
+By default, it removes IDs matching this pattern (ie. either all numeric or UUID) : `^\d+$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`.
+
+You can set your own regexp if you need to : 
+
+ `/project/a01/feature` becomes `/project/feature`
+ ````ts
+ Angulartics2Module.forRoot([providers], {
+   pageTracking: {
+     clearIds: true,
+     idsRegExp: /^[a-z]\d+$/,
+   }
+ }),
+ ````
+
+### Remove Query Params from url paths
+This can be combined with clearIds and idsRegExp
+
+`/project/12981/feature?param=12` becomes `/project/12981/feature`
+````ts
+Angulartics2Module.forRoot([providers], {
+  pageTracking: {
+    clearQueryParams: true,
+  }
+}),
+````
+
 
 ## Supported providers
 

--- a/src/lib/core/angulartics2-config.ts
+++ b/src/lib/core/angulartics2-config.ts
@@ -20,6 +20,10 @@ export interface PageTrackingSettings {
   excludedRoutes: (string | RegExp)[];
   /** drop ids from url `/sections/123/pages/456` -> `/sections/pages` */
   clearIds: boolean;
+  /** drop query params from url `/sections/123/pages?param=456&param2=789` -> `/sections/123/pages` */
+  clearQueryParams: boolean;
+  /** used with clearIds, define the matcher to clear url parts */
+  idsRegExp: RegExp;
 }
 
 export interface Angulartics2Settings {
@@ -37,6 +41,8 @@ export class DefaultConfig implements Angulartics2Settings {
     basePath: '',
     excludedRoutes: [],
     clearIds: false,
+    clearQueryParams: false,
+    idsRegExp: /^\d+$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
   };
   developerMode = false;
   ga = {};

--- a/src/lib/core/angulartics2.spec.ts
+++ b/src/lib/core/angulartics2.spec.ts
@@ -248,21 +248,56 @@ describe('angulartics2', () => {
           fixture = createRootWithRouter(router, RootCmp);
           angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
           angulartics2.settings.pageTracking.clearIds = false;
-          (<SpyLocation>location).simulateUrlPop('/sections/123/pages/456');
+          (<SpyLocation>location).simulateUrlPop('/sections/01234567-9ABC-DEF0-1234-56789ABCDEF0/pages/456');
           advance(fixture);
-          expect(EventSpy).toHaveBeenCalledWith({ path: '/sections/123/pages/456', location: location });
+          expect(EventSpy).toHaveBeenCalledWith({ path: '/sections/01234567-9ABC-DEF0-1234-56789ABCDEF0/pages/456', location: location });
       })));
 
-    it('should remove ids from url if clearIds is true',
+    it('should remove ids and uuids from url if clearIds is true',
       fakeAsync(inject([Router, Location, Angulartics2],
         (router: Router, location: Location, angulartics2: Angulartics2) => {
-        fixture = createRootWithRouter(router, RootCmp);
-        angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
-        angulartics2.settings.pageTracking.clearIds = true;
-        (<SpyLocation>location).simulateUrlPop('/sections/123/pages/456');
-        advance(fixture);
-        expect(EventSpy).toHaveBeenCalledWith({ path: '/sections/pages', location: location });
-      })));
+          fixture = createRootWithRouter(router, RootCmp);
+          angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
+          angulartics2.settings.pageTracking.clearIds = true;
+          (<SpyLocation>location).simulateUrlPop('/0sections0/01234567-9ABC-DEF0-1234-56789ABCDEF0/pages?param=456');
+          advance(fixture);
+          expect(EventSpy).toHaveBeenCalledWith({ path: '/0sections0/pages?param=456', location: location });
+        })));
+
+    it('should remove ids using custom regex if idsRegExp is set',
+      fakeAsync(inject([Router, Location, Angulartics2],
+        (router: Router, location: Location, angulartics2: Angulartics2) => {
+          fixture = createRootWithRouter(router, RootCmp);
+          angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
+          angulartics2.settings.pageTracking.clearIds = true;
+          angulartics2.settings.pageTracking.idsRegExp = /^[a-z]\d+$/;
+          (<SpyLocation>location).simulateUrlPop('/0sections0/a01/pages/page/2/summary?param=456');
+          advance(fixture);
+          expect(EventSpy).toHaveBeenCalledWith({ path: '/0sections0/pages/page/2/summary?param=456', location: location });
+        })));
+
+    it('should remove query params if clearQueryParams is set',
+      fakeAsync(inject([Router, Location, Angulartics2],
+        (router: Router, location: Location, angulartics2: Angulartics2) => {
+          fixture = createRootWithRouter(router, RootCmp);
+          angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
+          angulartics2.settings.pageTracking.clearQueryParams = true;
+          (<SpyLocation>location).simulateUrlPop('/0sections0/a01/pages/page/2/summary?param=456');
+          advance(fixture);
+          expect(EventSpy).toHaveBeenCalledWith({ path: '/0sections0/a01/pages/page/2/summary', location: location });
+        })));
+
+    it('should remove ids and query params if clearQueryParams and clearIds are set',
+      fakeAsync(inject([Router, Location, Angulartics2],
+        (router: Router, location: Location, angulartics2: Angulartics2) => {
+          fixture = createRootWithRouter(router, RootCmp);
+          angulartics2.pageTrack.subscribe((x: any) => EventSpy(x));
+          angulartics2.settings.pageTracking.clearQueryParams = true;
+          angulartics2.settings.pageTracking.clearIds = true;
+          (<SpyLocation>location).simulateUrlPop('/0sections0/01234567-9ABC-DEF0-1234-56789ABCDEF0/pages?param=456');
+          advance(fixture);
+          expect(EventSpy).toHaveBeenCalledWith({ path: '/0sections0/pages', location: location });
+        })));
   });
 
   describe('EventEmiters', function() {

--- a/src/lib/core/angulartics2.ts
+++ b/src/lib/core/angulartics2.ts
@@ -93,10 +93,11 @@ export class Angulartics2 {
    * @param url current page path
    */
   protected clearUrl(url: string): string {
-    if (this.settings.pageTracking.clearIds) {
+    if (this.settings.pageTracking.clearIds || this.settings.pageTracking.clearQueryParams) {
       return url
         .split('/')
-        .filter(part => !part.match(/\d+/))
+        .map(part => this.settings.pageTracking.clearQueryParams ? part.split('?')[0] : part)
+        .filter(part => !this.settings.pageTracking.clearIds || !part.match(this.settings.pageTracking.idsRegExp))
         .join('/');
     }
     return url;

--- a/src/lib/test.mocks.ts
+++ b/src/lib/test.mocks.ts
@@ -38,7 +38,10 @@ export const RoutesConfig: Routes = [
   { path: 'abc', component: HelloCmp2 },
   { path: 'def', component: HelloCmp3 },
   { path: 'ghi', component: HelloCmp4 },
-  { path: 'sections/123/pages/456', component: HelloCmp5 }
+  { path: 'sections/123/pages/456', component: HelloCmp5 },
+  { path: 'sections/01234567-9ABC-DEF0-1234-56789ABCDEF0/pages/456', component: HelloCmp5 },
+  { path: '0sections0/01234567-9ABC-DEF0-1234-56789ABCDEF0/pages', component: HelloCmp5 },
+  { path: '0sections0/a01/pages/page/2/summary', component: HelloCmp5 },
 ];
 
 @Component({


### PR DESCRIPTION
… added query params clearing

It is now possible via configuration to clear QueryParams alone, and set the RegExp used to clear
url parts. By default the clearUrl function now remove pure ids (only number) and UUIDs, and not
anything having a number in it

fix #204

* **What kind of change does this PR introduce?**



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
