### PR TITLE
feat(provider): GA - take into account "tracker" in all cases

### DIFF
--- a/src/lib/providers/ga/angulartics2-ga.spec.ts
+++ b/src/lib/providers/ga/angulartics2-ga.spec.ts
@@ -42,28 +42,36 @@ describe('Angulartics2GoogleAnalytics', () => {
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
         (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
           fixture = createRoot(RootCmp);
+          angulartics2.settings.ga.additionalAccountNames.push('additionalAccountName');
           angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
           advance(fixture);
           expect(ga).toHaveBeenCalledWith('send', 'event', { eventCategory: 'cat', eventAction: 'do', eventLabel: undefined, eventValue: undefined, nonInteraction: undefined, page: '/context.html', userId: null, hitCallback: undefined });
+          expect(ga).toHaveBeenCalledWith('additionalAccountName.send', 'event', { eventCategory: 'cat', eventAction: 'do', eventLabel: undefined, eventValue: undefined, nonInteraction: undefined, page: '/context.html', userId: null, hitCallback: undefined });
       })));
 
   it('should track events with hitCallback',
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
         (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
+          angulartics2.settings.ga.additionalAccountNames.push('additionalAccountName');
+
           fixture = createRoot(RootCmp);
           const callback = function() { };
           angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat', hitCallback: callback } });
           advance(fixture);
           expect(ga).toHaveBeenCalledWith('send', 'event', { eventCategory: 'cat', eventAction: 'do', eventLabel: undefined, eventValue: undefined, nonInteraction: undefined, page: '/context.html', userId: null, hitCallback: callback });
+          expect(ga).toHaveBeenCalledWith('additionalAccountName.send', 'event', { eventCategory: 'cat', eventAction: 'do', eventLabel: undefined, eventValue: undefined, nonInteraction: undefined, page: '/context.html', userId: null, hitCallback: callback });
       })));
 
   it('should track exceptions',
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
         (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
+          angulartics2.settings.ga.additionalAccountNames.push('additionalAccountName');
+
           fixture = createRoot(RootCmp);
           angulartics2.exceptionTrack.next({ fatal: true, description: 'test' });
           advance(fixture);
           expect(ga).toHaveBeenCalledWith('send', 'exception', { exFatal: true, exDescription: 'test' });
+          expect(ga).toHaveBeenCalledWith('additionalAccountName.send', 'exception', { exFatal: true, exDescription: 'test' });
       })));
 
   it('should set username',
@@ -109,9 +117,11 @@ describe('Angulartics2GoogleAnalytics', () => {
     fakeAsync(inject([Location, Angulartics2, Angulartics2GoogleAnalytics],
         (location: Location, angulartics2: Angulartics2, angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) => {
           fixture = createRoot(RootCmp);
+          angulartics2.settings.ga.additionalAccountNames.push('additionalAccountName');
           angulartics2.userTimings.next({ timingCategory: 'cat', timingVar: 'var', timingValue: 100 });
           advance(fixture);
           expect(ga).toHaveBeenCalledWith('send', 'timing', { timingCategory: 'cat', timingVar: 'var', timingValue: 100 });
+          expect(ga).toHaveBeenCalledWith('additionalAccountName.send', 'timing', { timingCategory: 'cat', timingVar: 'var', timingValue: 100 });
       })));
 
 });

--- a/src/lib/providers/ga/angulartics2-ga.ts
+++ b/src/lib/providers/ga/angulartics2-ga.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
+import {Injectable} from '@angular/core';
 
-import { Angulartics2, GoogleAnalyticsSettings } from 'angulartics2';
+import {Angulartics2, GoogleAnalyticsSettings} from 'angulartics2';
 
 declare var _gaq: GoogleAnalyticsCode;
 declare var ga: UniversalAnalytics.ga;
@@ -46,6 +46,9 @@ export class Angulartics2GoogleAnalytics {
     if (typeof ga !== 'undefined' && ga) {
       if (this.angulartics2.settings.ga.userId) {
         ga('set', '&uid', this.angulartics2.settings.ga.userId);
+        for (const accountName of this.angulartics2.settings.ga.additionalAccountNames) {
+          ga(accountName + '.set', '&uid', this.angulartics2.settings.ga.userId);
+        }
       }
       ga('send', 'pageview', path);
       for (const accountName of this.angulartics2.settings.ga.additionalAccountNames) {
@@ -134,6 +137,9 @@ export class Angulartics2GoogleAnalytics {
     };
 
     ga('send', 'exception', eventOptions);
+    for (const accountName of this.angulartics2.settings.ga.additionalAccountNames) {
+      ga(accountName + '.send', 'exception', eventOptions);
+    }
   }
 
   /**
@@ -157,6 +163,9 @@ export class Angulartics2GoogleAnalytics {
 
     if (typeof ga !== 'undefined') {
       ga('send', 'timing', properties);
+      for (const accountName of this.angulartics2.settings.ga.additionalAccountNames) {
+        ga(accountName + '.send', 'timing', properties);
+      }
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

It properly manages GA when tracker name is defined, i.e. when angulartics2.settings.ga.additionalAccountNames is set.

When GA tracker name is set, all calls to `ga()` require to prefix command with tracker name.
See https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers, especially
> To send pageviews for the above two trackers, you'd run the following two commands:
```
ga('send', 'pageview');
ga('clientTracker.send', 'pageview');
```
## What is the current behavior?

`angulartics2-ga.js` is partially taking into account angulartics2.settings.ga.additionalAccountNames, typically on:
* `angulartics2-ga.eventTrack(action, properties)` - but not for ga('set', '&uid', userId)
* `angulartics2-ga.pageTrack(path)`

## What is the new behavior (if this is a feature change)?

The missing places where 'accountName' is now managed
* `angulartics2-ga.pageTrack(path)` => add `ga(accountName + '.set', '&uid', userId)`
* `angulartics2-ga.exceptionTrack(properties)` => add `ga(accountName + '.send', 'exception', eventOptions)`
* `angulartics2-ga.userTimings(properties)` => add `ga(accountName + '.send', 'timing', properties)`
