### PR TITLE
remove ga tracking code from the index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,18 +245,32 @@ If there's no Angulartics2 plugin for your analytics vendor of choice, please fe
 
 ### Minimal setup for Google Analytics
 
-Add the full Google [analytics.js](https://developers.google.com/analytics/devguides/collection/analyticsjs/) tracking code to the beginning of your body tag.
+To setup Google Analytics add the folowing to main.ts
 
-#### Changes in the Google Analytics snippet
+```ts
+import {Angulartics2GoogleAnalytics} from "angulartics2/ga";
 
-The snippet code provided by Google Analytics does an automatic pageview hit, but this is already done by Angulartics (unless you disable it) so make sure to delete the tracking line:
 
-```html
-      ...
-      ga('create', 'UA-XXXXXXXX-X', 'none'); // 'none' while you are working on localhost
-      ga('send', 'pageview');  // DELETE THIS LINE!
-    </script>
+if (environment.production) {
+  // ...
+  Angulartics2GoogleAnalytics.prototype.createGaSession(environment.googleAnalytics);
+}
 ```
+
+you can add other environments if you want. In your environment.prod.ts add the configuration
+
+```ts
+export const environment = {
+  production: true,
+  // ...
+  googleAnalytics: {
+    domain: 'auto',
+    trackingId: 'UA-XXXXXXXX-X' // replace with your Tracking Id
+  }
+};
+```
+
+for localhost environments replace 'auto' with 'none'
 
 ## v4 Migration and Breaking Changes
 See [Release Notes](https://github.com/angulartics/angulartics2/releases/tag/v4.0.0)

--- a/src/lib/providers/ga/README.md
+++ b/src/lib/providers/ga/README.md
@@ -10,12 +10,31 @@ __docs__: [developers.google.com/analytics/devguides/collection/analyticsjs/](ht
 __import__: `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';`  
 
 ## Setup
-1. Add tracking code [provided by Google](https://developers.google.com/analytics/devguides/collection/analyticsjs/)
-2. Remove `ga('send', 'pageview');` to prevent duplicate pageview
-```html
-  ...
-  ga('create', 'UA-XXXXXXXX-X', 'none'); // 'none' while you are working on localhost
-  ga('send', 'pageview');  // DELETE THIS LINE!
-</script>
+1. To setup Google Analytics add the folowing to main.ts
+
+```ts
+import {Angulartics2GoogleAnalytics} from "angulartics2/ga";
+
+
+if (environment.production) {
+  // ...
+  Angulartics2GoogleAnalytics.prototype.createGaSession(environment.googleAnalytics);
+}
 ```
+
+2. you can add other environments if you want. In your environment.prod.ts add the configuration
+
+```ts
+export const environment = {
+  production: true,
+  // ...
+  googleAnalytics: {
+    domain: 'auto',
+    trackingId: 'UA-XXXXXXXX-X' // replace with your Tracking Id
+  }
+};
+```
+
+for localhost environments replace 'auto' with 'none'
+
 3. [Setup Angulartics](https://github.com/angulartics/angulartics2/tree/next#installation) using `Angulartics2GoogleAnalytics`

--- a/src/lib/providers/ga/angulartics2-ga.ts
+++ b/src/lib/providers/ga/angulartics2-ga.ts
@@ -227,4 +227,17 @@ export class Angulartics2GoogleAnalytics {
       }
     });
   }
+
+  createGaSession(settings:{trackingId: string, domain: string}) {
+    document.write(
+      "<script>" +
+      "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){" +
+      "(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o)," +
+      "m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)" +
+      "})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');" +
+
+      "ga('create', '" + settings.trackingId + "' , '" + settings.domain + "');" +
+      "</script>"
+    );
+  }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
full ts solution for implementation of Google Analytics.

* **What is the current behavior?** (You can also link to an open issue here)
to use ga you have to include js into the index.html file of the Angular app. This way there is no possibility to use environment variables.

* **What is the new behavior (if this is a feature change)?**
By adding the Google code using typescript inside main.ts it is possible to get tracking id and domain from environment.ts. this way it is possible to use different settings for different environments

* **Other information**:
