### PR TITLE
Make it easier to differentiate analytics.js and gtag.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ import { Angulartics2UirouterModule } from 'angulartics2/uiroutermodule';
 
 ## Supported providers
 
-* [Google Analytics](/src/lib/providers/ga)
-* [Google Tag Manager](/src/lib/providers/gtm)
+* [Google Analytics](/src/lib/providers/ga) (`analytics.js`)
+* [Google Tag Manager](/src/lib/providers/gtm) (`gtag.js`)
 * [Google Enhanced Ecom](/src/lib/providers/ga-enhanced-ecom)
 * [Kissmetrics](/src/lib/providers/kissmetrics)
 * [Mixpanel](/src/lib/providers/mixpanel)

--- a/src/lib/providers/ga/README.md
+++ b/src/lib/providers/ga/README.md
@@ -15,6 +15,7 @@ __import__: `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';`
 1. Add [`analytics.js` tracking code provided by Google](https://developers.google.com/analytics/devguides/collection/analyticsjs/) to the beginning of your body tag.
 2. Remove `ga('send', 'pageview');` to prevent duplicate pageview (as this is also done by angulartics):
 ```html
+<script>
   ...
   ga('create', 'UA-XXXXXXXX-X', 'none'); // 'none' while you are working on localhost
   ga('send', 'pageview');  // DELETE THIS LINE!

--- a/src/lib/providers/ga/README.md
+++ b/src/lib/providers/ga/README.md
@@ -23,4 +23,4 @@ __import__: `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';`
 ```
 3. [Setup Angulartics](https://github.com/angulartics/angulartics2/tree/next#installation) using `Angulartics2GoogleAnalytics`
 
-Note: If Google Analytics suggest you use `gtag.js` code, either switch to `analytics.js` or have a look at the instructions for  [Google Tag Manager](/src/lib/providers/gtm).
+> Note: If Google Analytics suggest you use `gtag.js` code, either switch to `analytics.js` or have a look at the instructions for  [Google Tag Manager](/src/lib/providers/gtm).

--- a/src/lib/providers/ga/README.md
+++ b/src/lib/providers/ga/README.md
@@ -4,14 +4,16 @@
     height="100px"
     width="200px" />
 
-# Google Analytics
+# Google Analytics (`analytics.js`)
+
 __homepage__: [google.com/analytics](https://www.google.com/analytics)  
 __docs__: [developers.google.com/analytics/devguides/collection/analyticsjs/](https://developers.google.com/analytics/devguides/collection/analyticsjs/)  
 __import__: `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';`  
 
 ## Setup
-1. Add tracking code [provided by Google](https://developers.google.com/analytics/devguides/collection/analyticsjs/)
-2. Remove `ga('send', 'pageview');` to prevent duplicate pageview
+
+1. Add [`analytics.js` tracking code provided by Google](https://developers.google.com/analytics/devguides/collection/analyticsjs/) to the beginning of your body tag.
+2. Remove `ga('send', 'pageview');` to prevent duplicate pageview (as this is also done by angulartics):
 ```html
   ...
   ga('create', 'UA-XXXXXXXX-X', 'none'); // 'none' while you are working on localhost
@@ -19,3 +21,5 @@ __import__: `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';`
 </script>
 ```
 3. [Setup Angulartics](https://github.com/angulartics/angulartics2/tree/next#installation) using `Angulartics2GoogleAnalytics`
+
+Note: If Google Analytics suggest you use `gtag.js` code, either switch to `analytics.js` or have a look at the instructions for  [Google Tag Manager](/src/lib/providers/gtm).

--- a/src/lib/providers/ga/README.md
+++ b/src/lib/providers/ga/README.md
@@ -13,6 +13,7 @@ __import__: `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';`
 ## Setup
 
 1. Add [`analytics.js` tracking code provided by Google](https://developers.google.com/analytics/devguides/collection/analyticsjs/) to the beginning of your body tag.
+> Note: If Google Analytics suggest you use `gtag.js` code, either switch to `analytics.js` or have a look at the instructions for  [Google Tag Manager](/src/lib/providers/gtm).
 2. Remove `ga('send', 'pageview');` to prevent duplicate pageview (as this is also done by angulartics):
 ```html
 <script>
@@ -22,5 +23,3 @@ __import__: `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';`
 </script>
 ```
 3. [Setup Angulartics](https://github.com/angulartics/angulartics2/tree/next#installation) using `Angulartics2GoogleAnalytics`
-
-> Note: If Google Analytics suggest you use `gtag.js` code, either switch to `analytics.js` or have a look at the instructions for  [Google Tag Manager](/src/lib/providers/gtm).

--- a/src/lib/providers/ga/README.md
+++ b/src/lib/providers/ga/README.md
@@ -13,7 +13,7 @@ __import__: `import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';`
 ## Setup
 
 1. Add [`analytics.js` tracking code provided by Google](https://developers.google.com/analytics/devguides/collection/analyticsjs/) to the beginning of your body tag.
-> Note: If Google Analytics suggest you use `gtag.js` code, either switch to `analytics.js` or have a look at the instructions for  [Google Tag Manager](/src/lib/providers/gtm).
+> Note: If Google Analytics suggest you use `gtag.js` tracking code, either switch to `analytics.js`, or have a look at the instructions for [Google Tag Manager](/src/lib/providers/gtm).
 2. Remove `ga('send', 'pageview');` to prevent duplicate pageview (as this is also done by angulartics):
 ```html
 <script>

--- a/src/lib/providers/gtm/README.md
+++ b/src/lib/providers/gtm/README.md
@@ -4,7 +4,7 @@
     height="100px"
     width="200px" />
 
-# Google Tag Manager
+# Google Tag Manager (gtag.js)
 __homepage__: [google.com/analytics/tag-manager](https://www.google.com/analytics/tag-manager/)  
 __docs__: [developers.google.com/tag-manager/devguide](https://developers.google.com/tag-manager/devguide)  
 __import__: `import { Angulartics2GoogleTagManager } from 'angulartics2/gtm';`  

--- a/src/lib/providers/gtm/README.md
+++ b/src/lib/providers/gtm/README.md
@@ -4,7 +4,7 @@
     height="100px"
     width="200px" />
 
-# Google Tag Manager (gtag.js)
+# Google Tag Manager (`gtag.js`)
 __homepage__: [google.com/analytics/tag-manager](https://www.google.com/analytics/tag-manager/)  
 __docs__: [developers.google.com/tag-manager/devguide](https://developers.google.com/tag-manager/devguide)  
 __import__: `import { Angulartics2GoogleTagManager } from 'angulartics2/gtm';`  


### PR DESCRIPTION
Added some note and links to make clearer that gtag.js (which Google Analytics now pushes by default) is actually Google Tag Manager.

fixes #225