### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can set your own regexp if you need to :
  Angulartics2Module.forRoot([providers], {
    pageTracking: {
      clearIds: true,
-     idsRegExp: /^[a-z]\d+$/,
+     idsRegExp: new RegExp('^[a-z]\\d+$') /* Workaround: No NgModule metadata found for 'AppModule' */
    }
  }),
  ````


### PR DESCRIPTION
Workaround: No NgModule metadata found for 'AppModule'

* **What kind of change does this PR introduce?**



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
