### PR TITLE
fix(providers): HubSpot - Don't initialize _hsq object

### DIFF
--- a/src/lib/providers/hubspot/angulartics2-hubspot.ts
+++ b/src/lib/providers/hubspot/angulartics2-hubspot.ts
@@ -10,10 +10,6 @@ export class Angulartics2Hubspot {
   constructor(
     private angulartics2: Angulartics2
   ) {
-    if (typeof _hsq === 'undefined') {
-      _hsq = [];
-    }
-
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));


### PR DESCRIPTION
Don't try to assign / initialize _hsq window object if it doesn't exist. This can cause errors in applications. (`ReferenceError: _hsq is not defined`)

the _gaq and ga objects are not initialized in this way in the google analytics integration.

* **What kind of change does this PR introduce?**

This removes the code attempting to initialize the value of _hsq to an empty array if the type is undefined.

* **What is the current behavior?** (You can also link to an open issue here)

Currently, in some environments where adblock or other means are used to prevent hubspot loading, _hsq does not exist. Trying to assign a value to this variable throws an error (`ReferenceError: _hsq is not defined`)

* **What is the new behavior (if this is a feature change)?**

if _hsq does not exist, it will not be assigned a value. 

* **Other information**:
