### PR TITLE
fix: Added ibm-digital-analytics to build list

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -23,6 +23,7 @@ const MODULE_NAMES = [
   'woopra',
   'clicky',
   'amplitude',
+  'ibm-digital-analytics'
 ];
 
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
ibm-digital-analytics was missing from the build list so it was not being build and is missing from the npm package.

- **What is the current behavior? Link to open issue?**
ibm-digital-analytics is missing from the npm package

- **What is the new behavior?**
ibm-digital-analytics is now part of the build list and will be added to the npm package on next build