### PR TITLE
feat(core): add "start tracking" method and require on all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,16 @@ const ROUTES: Routes = [
 ```
 > Note the different imports when [Using Without A Router](#using-without-a-router) or [Using With UI-Router](#using-with-ui-router).
 
-2. __Required__: Import your providers in the root component. This starts the tracking of route changes.
+2. __Required__: Import your providers in the root component. Call `startTracking()` to start the tracking of route changes.
 ```ts
 // component
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 
 @Component({  ...  })
 export class AppComponent {
-  constructor(angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) {}
+  constructor(angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) {
+    angulartics2GoogleAnalytics.startTracking();
+  }
 }
 ```
 

--- a/src/lib/providers/adobeanalytics/adobeanalytics.spec.ts
+++ b/src/lib/providers/adobeanalytics/adobeanalytics.spec.ts
@@ -29,6 +29,9 @@ describe('Angulartics2AdobeAnalytics', () => {
     });
 
     window.s = s = jasmine.createSpyObj('s', ['clearVars', 't', 'tl']);
+
+    const provider: Angulartics2AdobeAnalytics = TestBed.get(Angulartics2AdobeAnalytics);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/adobeanalytics/adobeanalytics.ts
+++ b/src/lib/providers/adobeanalytics/adobeanalytics.ts
@@ -12,14 +12,17 @@ export class Angulartics2AdobeAnalytics {
     private angulartics2: Angulartics2,
     private location: Location,
   ) {
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+  }
+
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));
     this.angulartics2.eventTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.eventTrack(x.action, x.properties));
-    this.angulartics2.setUserProperties
-      .subscribe((x) => this.setUserProperties(x));
   }
 
   pageTrack(path: string) {

--- a/src/lib/providers/amplitude/amplitude.spec.ts
+++ b/src/lib/providers/amplitude/amplitude.spec.ts
@@ -32,6 +32,9 @@ describe('Angulartics2Amplitude', () => {
         return amplitudeMock;
       }
     };
+
+    const provider: Angulartics2Amplitude = TestBed.get(Angulartics2Amplitude);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/amplitude/amplitude.ts
+++ b/src/lib/providers/amplitude/amplitude.ts
@@ -14,18 +14,21 @@ declare var amplitude: {
 export class Angulartics2Amplitude {
 
   constructor(private angulartics2: Angulartics2) {
-    this.angulartics2.pageTrack
-      .pipe(this.angulartics2.filterDeveloperMode())
-      .subscribe((x: any) => this.pageTrack(x.path));
-    this.angulartics2.eventTrack
-      .pipe(this.angulartics2.filterDeveloperMode())
-      .subscribe((x: any) => this.eventTrack(x.action, x.properties));
     this.angulartics2.setUsername
       .subscribe((x: any) => this.setUsername(x));
     this.angulartics2.setUserProperties
       .subscribe((x: any) => this.setUserProperties(x));
     this.angulartics2.setUserPropertiesOnce
       .subscribe((x: any) => this.setUserProperties(x));
+  }
+
+  startTracking(): void {
+    this.angulartics2.pageTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x: any) => this.pageTrack(x.path));
+    this.angulartics2.eventTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x: any) => this.eventTrack(x.action, x.properties));
   }
 
   pageTrack(path: string) {

--- a/src/lib/providers/appinsights/appinsights.spec.ts
+++ b/src/lib/providers/appinsights/appinsights.spec.ts
@@ -32,7 +32,10 @@ describe('Angulartics2AppInsights', () => {
         'trackException',
         'setAuthenticatedUserContext',
       ]);
-    });
+
+    const provider: Angulartics2AppInsights = TestBed.get(Angulartics2AppInsights);
+    provider.startTracking();
+  });
 
   it('should track pages',
     fakeAsync(inject([Angulartics2, Angulartics2AppInsights, Title],

--- a/src/lib/providers/appinsights/appinsights.ts
+++ b/src/lib/providers/appinsights/appinsights.ts
@@ -37,7 +37,13 @@ export class Angulartics2AppInsights {
     const defaults = new AppInsightsDefaults;
     // Set the default settings for this module
     this.angulartics2.settings.appInsights = { ...defaults, ...this.angulartics2.settings.appInsights };
+    this.angulartics2.setUsername
+      .subscribe((x: string) => this.setUsername(x));
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+  }
 
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));
@@ -47,15 +53,11 @@ export class Angulartics2AppInsights {
     this.angulartics2.exceptionTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.exceptionTrack(x));
-    this.angulartics2.setUsername
-      .subscribe((x: string) => this.setUsername(x));
-    this.angulartics2.setUserProperties
-      .subscribe((x) => this.setUserProperties(x));
     this.router.events
       .pipe(
         this.angulartics2.filterDeveloperMode(),
         filter(event => event instanceof NavigationStart),
-      )
+    )
       .subscribe(event => this.startTimer());
 
     this.router.events

--- a/src/lib/providers/baidu/baidu.spec.ts
+++ b/src/lib/providers/baidu/baidu.spec.ts
@@ -24,6 +24,9 @@ describe('Angulartics2BaiduAnalytics', () => {
       });
 
       window._hmt = _hmt = [];
+
+      const provider: Angulartics2BaiduAnalytics = TestBed.get(Angulartics2BaiduAnalytics);
+      provider.startTracking();
     });
 
   it('should track pages',

--- a/src/lib/providers/baidu/baidu.ts
+++ b/src/lib/providers/baidu/baidu.ts
@@ -13,17 +13,19 @@ export class Angulartics2BaiduAnalytics {
     } else {
       _hmt.push(['_setAutoPageview', false]);
     }
+    this.angulartics2.setUsername
+      .subscribe((x: string) => this.setUsername(x));
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+  }
 
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));
     this.angulartics2.eventTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.eventTrack(x.action, x.properties));
-    this.angulartics2.setUsername
-      .subscribe((x: string) => this.setUsername(x));
-    this.angulartics2.setUserProperties
-      .subscribe((x) => this.setUserProperties(x));
   }
 
   /**

--- a/src/lib/providers/clicky/README.md
+++ b/src/lib/providers/clicky/README.md
@@ -75,7 +75,9 @@ import { Angulartics2Clicky } from 'angulartics2-clicky';
 })
 export class AppComponent {
   // Enable auto route logging
-  constructor(angulartics2Clicky: Angulartics2Clicky) {}
+  constructor(angulartics2Clicky: Angulartics2Clicky) {
+    angulartics2Clicky.startTracking();
+  }
 }
 ```
 

--- a/src/lib/providers/clicky/clicky.spec.ts
+++ b/src/lib/providers/clicky/clicky.spec.ts
@@ -46,6 +46,8 @@ describe('Angulartics2Clicky', () => {
   describe('while active', () => {
     beforeEach(() => {
       window.clicky = clicky = jasmine.createSpyObj('clicky', ['log', 'goal']);
+      const provider: Angulartics2Clicky = TestBed.get(Angulartics2Clicky);
+      provider.startTracking();
     });
 
     it('should track pages',

--- a/src/lib/providers/clicky/clicky.ts
+++ b/src/lib/providers/clicky/clicky.ts
@@ -15,6 +15,9 @@ export class Angulartics2Clicky {
     if (typeof clicky === 'undefined') {
       console.warn('Angulartics 2 Clicky Plugin: clicky global not found');
     }
+  }
+
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));

--- a/src/lib/providers/facebook/facebook.spec.ts
+++ b/src/lib/providers/facebook/facebook.spec.ts
@@ -18,6 +18,8 @@ describe('Angulartics2Facebook', () => {
     });
 
     window.fbq = fbq = jasmine.createSpy('fbq');
+    const provider: Angulartics2Facebook = TestBed.get(Angulartics2Facebook);
+    provider.startTracking();
   });
 
   it('should track events',

--- a/src/lib/providers/facebook/facebook.ts
+++ b/src/lib/providers/facebook/facebook.ts
@@ -18,7 +18,9 @@ const facebookEventList = [
 
 @Injectable()
 export class Angulartics2Facebook {
-  constructor(private angulartics2: Angulartics2) {
+  constructor(private angulartics2: Angulartics2) { }
+
+  startTracking(): void {
     this.angulartics2.eventTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe(x => this.eventTrack(x.action, x.properties));

--- a/src/lib/providers/ga/ga.spec.ts
+++ b/src/lib/providers/ga/ga.spec.ts
@@ -20,6 +20,9 @@ describe('Angulartics2GoogleAnalytics', () => {
     });
     window.ga = ga = jasmine.createSpy('ga');
     window._gaq = _gaq = [];
+
+    const service: Angulartics2GoogleAnalytics = TestBed.get(Angulartics2GoogleAnalytics);
+    service.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/ga/ga.ts
+++ b/src/lib/providers/ga/ga.ts
@@ -29,6 +29,11 @@ export class Angulartics2GoogleAnalytics {
       ...defaults,
       ...this.angulartics2.settings.ga,
     };
+    this.angulartics2.setUsername.subscribe((x: string) => this.setUsername(x));
+    this.angulartics2.setUserProperties.subscribe(x => this.setUserProperties(x));
+  }
+
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe(x => this.pageTrack(x.path));
@@ -38,8 +43,6 @@ export class Angulartics2GoogleAnalytics {
     this.angulartics2.exceptionTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe(x => this.exceptionTrack(x));
-    this.angulartics2.setUsername.subscribe((x: string) => this.setUsername(x));
-    this.angulartics2.setUserProperties.subscribe(x => this.setUserProperties(x));
     this.angulartics2.userTimings
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe(x => this.userTimings(x));

--- a/src/lib/providers/gtm/README.md
+++ b/src/lib/providers/gtm/README.md
@@ -26,7 +26,9 @@ import { Angulartics2GoogleTagManager } from 'angulartics2/gtm';
 @Component({ ... })
 export class AppComponent {
   // import Angulartics2GoogleTagManager in root component
-  constructor(angulartics2GoogleTagManager: Angulartics2GoogleTagManager) {}
+  constructor(angulartics2GoogleTagManager: Angulartics2GoogleTagManager) {
+    angulartics2GoogleTagManager.startTracking();
+  }
 }
 ```
 

--- a/src/lib/providers/gtm/gtm.spec.ts
+++ b/src/lib/providers/gtm/gtm.spec.ts
@@ -18,6 +18,8 @@ describe('Angulartics2GoogleTagManager', () => {
     });
 
     window.dataLayer = dataLayer = [];
+    const provider: Angulartics2GoogleTagManager = TestBed.get(Angulartics2GoogleTagManager);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/gtm/gtm.ts
+++ b/src/lib/providers/gtm/gtm.ts
@@ -21,7 +21,11 @@ export class Angulartics2GoogleTagManager {
     const defaults = new GoogleTagManagerDefaults;
     // Set the default settings for this module
     this.angulartics2.settings.gtm = { ...defaults, ...this.angulartics2.settings.gtm };
+    this.angulartics2.setUsername
+      .subscribe((x: string) => this.setUsername(x));
+  }
 
+  startTracking() {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));
@@ -31,8 +35,6 @@ export class Angulartics2GoogleTagManager {
     this.angulartics2.exceptionTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x: any) => this.exceptionTrack(x));
-    this.angulartics2.setUsername
-      .subscribe((x: string) => this.setUsername(x));
   }
 
   pageTrack(path: string) {

--- a/src/lib/providers/hubspot/hubspot.spec.ts
+++ b/src/lib/providers/hubspot/hubspot.spec.ts
@@ -18,6 +18,8 @@ describe('Angulartics2Hubspot', () => {
     });
 
     window._hsq = _hsq = [];
+    const provider: Angulartics2Hubspot = TestBed.get(Angulartics2Hubspot);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/hubspot/hubspot.ts
+++ b/src/lib/providers/hubspot/hubspot.ts
@@ -10,14 +10,17 @@ export class Angulartics2Hubspot {
   constructor(
     private angulartics2: Angulartics2
   ) {
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+  }
+
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));
     this.angulartics2.eventTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.eventTrack(x.action, x.properties));
-    this.angulartics2.setUserProperties
-      .subscribe((x) => this.setUserProperties(x));
   }
 
   pageTrack(path: string) {

--- a/src/lib/providers/ibm-digital-analytics/README.md
+++ b/src/lib/providers/ibm-digital-analytics/README.md
@@ -71,8 +71,10 @@ import { Angulartics2IBMDigitalAnalytics } from 'angulartics2/ibm-digital-analyt
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-  // Enable auto route logging
-  constructor(angulartics2IBMDigitalAnalytics: Angulartics2IBMDigitalAnalytics) {}
+  // Enable route logging
+  constructor(angulartics2IBMDigitalAnalytics: Angulartics2IBMDigitalAnalytics) {
+      angulartics2IBMDigitalAnalytics.startTracking();
+  }
 }
 ```
 

--- a/src/lib/providers/ibm-digital-analytics/ibm-digital-analytics.spec.ts
+++ b/src/lib/providers/ibm-digital-analytics/ibm-digital-analytics.spec.ts
@@ -21,7 +21,6 @@ describe('Angulartics2IBMDigitalAnalytics', () => {
             providers: [Angulartics2IBMDigitalAnalytics],
         });
         window.console = jasmine.createSpyObj('console', ['warn', 'log']);
-
     });
 
     describe('on init', () => {
@@ -52,6 +51,8 @@ describe('Angulartics2IBMDigitalAnalytics', () => {
             window.cmCreateElementTag = jasmine.createSpy('cmCreateElementTag');
             window.cmCreateConversionEventTag = jasmine.createSpy('cmCreateConversionEventTag');
             window.cmDisplayShops = jasmine.createSpy('cmDisplayShops');
+            const provider: Angulartics2IBMDigitalAnalytics = TestBed.get(Angulartics2IBMDigitalAnalytics);
+            provider.startTracking();
         });
 
         it('should track pages',

--- a/src/lib/providers/ibm-digital-analytics/ibm-digital-analytics.ts
+++ b/src/lib/providers/ibm-digital-analytics/ibm-digital-analytics.ts
@@ -7,7 +7,9 @@ export class Angulartics2IBMDigitalAnalytics {
         if (typeof window['cmCreatePageviewTag'] !== 'function') {
             console.warn('Angulartics 2 IBM Digital Analytics Plugin: eluminate.js is not loaded');
         }
+    }
 
+    startTracking(): void {
         this.angulartics2.pageTrack
             .pipe(this.angulartics2.filterDeveloperMode())
             .subscribe((x) => this.pageTrack(x.path));

--- a/src/lib/providers/intercom/intercom.spec.ts
+++ b/src/lib/providers/intercom/intercom.spec.ts
@@ -27,6 +27,8 @@ describe('Angulartics2Intercom', () => {
     });
 
     window.Intercom = Intercom = jasmine.createSpy('Intercom');
+    const provider: Angulartics2Intercom = TestBed.get(Angulartics2Intercom);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/intercom/intercom.ts
+++ b/src/lib/providers/intercom/intercom.ts
@@ -10,16 +10,19 @@ export class Angulartics2Intercom {
   constructor(
     private angulartics2: Angulartics2
   ) {
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+    this.angulartics2.setUserPropertiesOnce
+      .subscribe((x) => this.setUserProperties(x));
+  }
+
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));
     this.angulartics2.eventTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.eventTrack(x.action, x.properties));
-    this.angulartics2.setUserProperties
-      .subscribe((x) => this.setUserProperties(x));
-    this.angulartics2.setUserPropertiesOnce
-      .subscribe((x) => this.setUserProperties(x));
   }
 
   pageTrack(path: string) {

--- a/src/lib/providers/kissmetrics/kissmetrics.spec.ts
+++ b/src/lib/providers/kissmetrics/kissmetrics.spec.ts
@@ -18,6 +18,8 @@ describe('Angulartics2Kissmetrics', () => {
     });
 
     window._kmq = _kmq = [];
+    const provider: Angulartics2Kissmetrics = TestBed.get(Angulartics2Kissmetrics);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/kissmetrics/kissmetrics.ts
+++ b/src/lib/providers/kissmetrics/kissmetrics.ts
@@ -13,17 +13,19 @@ export class Angulartics2Kissmetrics {
     if (typeof (_kmq) === 'undefined') {
       _kmq = [];
     }
+    this.angulartics2.setUsername
+      .subscribe((x: string) => this.setUsername(x));
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+  }
 
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));
     this.angulartics2.eventTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.eventTrack(x.action, x.properties));
-    this.angulartics2.setUsername
-      .subscribe((x: string) => this.setUsername(x));
-    this.angulartics2.setUserProperties
-      .subscribe((x) => this.setUserProperties(x));
   }
 
   pageTrack(path: string) {

--- a/src/lib/providers/mixpanel/mixpanel.spec.ts
+++ b/src/lib/providers/mixpanel/mixpanel.spec.ts
@@ -29,6 +29,9 @@ describe('Angulartics2Mixpanel', () => {
       register_once: jasmine.createSpy('register_once'),
       alias: jasmine.createSpy('alias'),
     };
+
+    const provider: Angulartics2Mixpanel = TestBed.get(Angulartics2Mixpanel);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/mixpanel/mixpanel.ts
+++ b/src/lib/providers/mixpanel/mixpanel.ts
@@ -10,12 +10,6 @@ export class Angulartics2Mixpanel {
   constructor(
     private angulartics2: Angulartics2
   ) {
-    this.angulartics2.pageTrack
-      .pipe(this.angulartics2.filterDeveloperMode())
-      .subscribe((x) => this.pageTrack(x.path));
-    this.angulartics2.eventTrack
-      .pipe(this.angulartics2.filterDeveloperMode())
-      .subscribe((x) => this.eventTrack(x.action, x.properties));
     this.angulartics2.setUsername
       .subscribe((x: string) => this.setUsername(x));
     this.angulartics2.setUserProperties
@@ -28,6 +22,15 @@ export class Angulartics2Mixpanel {
       .subscribe((x) => this.setSuperPropertiesOnce(x));
     this.angulartics2.setAlias
       .subscribe((x) => this.setAlias(x));
+  }
+
+  startTracking(): void {
+    this.angulartics2.pageTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.pageTrack(x.path));
+    this.angulartics2.eventTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.eventTrack(x.action, x.properties));
   }
 
   pageTrack(path: string) {

--- a/src/lib/providers/piwik/README.md
+++ b/src/lib/providers/piwik/README.md
@@ -46,8 +46,10 @@ Inject angulartics into your root component (usually appComponent)
 ```ts
 import { Angulartics2Piwik } from 'angulartics2/piwik';
 export class AppComponent {
-  // inject Angulartics2Piwik in root component to initialize it
-  constructor(private angulartics2Piwik: Angulartics2Piwik){ }
+  // inject Angulartics2Piwik in root component and initialize it
+  constructor(private angulartics2Piwik: Angulartics2Piwik) {
+    angulartics2Piwik.startTracking();
+  }
 }
 ```
 

--- a/src/lib/providers/piwik/piwik.spec.ts
+++ b/src/lib/providers/piwik/piwik.spec.ts
@@ -18,6 +18,8 @@ describe('Angulartics2Piwik', () => {
     });
 
     window._paq = _paq = [];
+    const provider: Angulartics2Piwik = TestBed.get(Angulartics2Piwik);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/piwik/piwik.ts
+++ b/src/lib/providers/piwik/piwik.ts
@@ -11,16 +11,19 @@ export class Angulartics2Piwik {
     if (typeof (_paq) === 'undefined') {
       console.warn('Piwik not found');
     }
+    this.angulartics2.setUsername
+      .subscribe((x: string) => this.setUsername(x));
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+  }
+
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));
     this.angulartics2.eventTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.eventTrack(x.action, x.properties));
-    this.angulartics2.setUsername
-      .subscribe((x: string) => this.setUsername(x));
-    this.angulartics2.setUserProperties
-      .subscribe((x) => this.setUserProperties(x));
   }
 
   pageTrack(path: string, location?: any) {

--- a/src/lib/providers/segment/README.md
+++ b/src/lib/providers/segment/README.md
@@ -43,6 +43,8 @@ import { Angulartics2Segment } from 'angulartics2/segment';
 
 @Component({  ...  })
 export class AppComponent {
-  constructor(angulartics2Segment: Angulartics2Segment) {}
+  constructor(angulartics2Segment: Angulartics2Segment) {
+    angulartics2Segment.startTracking();
+  }
 }
 ```

--- a/src/lib/providers/segment/segment.spec.ts
+++ b/src/lib/providers/segment/segment.spec.ts
@@ -29,6 +29,9 @@ describe('Angulartics2Segment', () => {
       identify: jasmine.createSpy('identify'),
       alias: jasmine.createSpy('alias')
     };
+
+    const provider: Angulartics2Segment = TestBed.get(Angulartics2Segment);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/segment/segment.ts
+++ b/src/lib/providers/segment/segment.ts
@@ -10,18 +10,21 @@ export class Angulartics2Segment {
   constructor(
     private angulartics2: Angulartics2
   ) {
-    this.angulartics2.pageTrack
-      .pipe(this.angulartics2.filterDeveloperMode())
-      .subscribe((x) => this.pageTrack(x.path));
-    this.angulartics2.eventTrack
-      .pipe(this.angulartics2.filterDeveloperMode())
-      .subscribe((x) => this.eventTrack(x.action, x.properties));
     this.angulartics2.setUserProperties
       .subscribe((x) => this.setUserProperties(x));
     this.angulartics2.setUserPropertiesOnce
       .subscribe((x) => this.setUserProperties(x));
     this.angulartics2.setAlias
       .subscribe((x) => this.setAlias(x));
+  }
+
+  startTracking(): void {
+    this.angulartics2.pageTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.pageTrack(x.path));
+    this.angulartics2.eventTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.eventTrack(x.action, x.properties));
   }
 
   /**

--- a/src/lib/providers/splunk/README.md
+++ b/src/lib/providers/splunk/README.md
@@ -51,6 +51,8 @@ import { Angulartics2Splunk } from 'angulartics2/splunk';
 
 @Component({  ...  })
 export class AppComponent {
-  constructor(angulartics2Splunk: Angulartics2Splunk) {}
+  constructor(angulartics2Splunk: Angulartics2Splunk) {
+    angulartics2Splunk.startTracking();
+  }
 }
 ```

--- a/src/lib/providers/splunk/splunk.spec.ts
+++ b/src/lib/providers/splunk/splunk.spec.ts
@@ -27,6 +27,9 @@ describe('Angulartics2Splunk', () => {
       pageview: jasmine.createSpy('pageview'),
       track: jasmine.createSpy('track')
     };
+
+    const provider: Angulartics2Splunk = TestBed.get(Angulartics2Splunk);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/splunk/splunk.ts
+++ b/src/lib/providers/splunk/splunk.ts
@@ -11,7 +11,9 @@ export class Angulartics2Splunk {
     if (typeof (sp) === 'undefined') {
       console.warn('Splunk not found');
     }
+  }
 
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));

--- a/src/lib/providers/woopra/woopra.spec.ts
+++ b/src/lib/providers/woopra/woopra.spec.ts
@@ -26,6 +26,9 @@ describe('Angulartics2Woopra', () => {
       track: jasmine.createSpy('track'),
       identify: jasmine.createSpy('identify'),
     };
+
+    const provider: Angulartics2Woopra = TestBed.get(Angulartics2Woopra);
+    provider.startTracking();
   });
 
   it('should track pages',

--- a/src/lib/providers/woopra/woopra.ts
+++ b/src/lib/providers/woopra/woopra.ts
@@ -13,14 +13,17 @@ export class Angulartics2Woopra {
       console.warn('Woopra not found');
     }
 
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+  }
+
+  startTracking(): void {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.pageTrack(x.path));
     this.angulartics2.eventTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.eventTrack(x.action, x.properties));
-    this.angulartics2.setUserProperties
-      .subscribe((x) => this.setUserProperties(x));
   }
 
   pageTrack(path: string) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
* add a method to initiate event tracking

- **What is the current behavior? Link to open issue?**
* event tracking is automatically initiated upon provider instantiation. #282 

- **What is the new behavior?**
breaking change: `startTracking()` must be called to start event tracking pageTrack, eventTrack, exceptionTrack, and userTimings calls.

This may be a little ambitious, but I attempted to add an initiator method for each provider.

closes #282 
