### PR TITLE
feat: Google Global Site Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ System.config({
 * [Google Analytics](/src/lib/providers/ga) (`analytics.js`)
 * [Google Tag Manager](/src/lib/providers/gtm) (`gtag.js`)
 * [Google Enhanced Ecom](/src/lib/providers/ga-enhanced-ecom)
+* [Google Global Site Tag](/src/lib/providers/gst) (`gtag.js`)
 * [Kissmetrics](/src/lib/providers/kissmetrics)
 * [Mixpanel](/src/lib/providers/mixpanel)
 * [Piwik](/src/lib/providers/piwik)
@@ -282,6 +283,7 @@ If there's no Angulartics2 plugin for your analytics vendor of choice, please fe
 
 - See [Google Analytics](/src/lib/providers/ga) if your code snippet contains `analytics.js`
 - See [Google Tag Manager](/src/lib/providers/gtm) if your code snippet contains `gtag.js`
+- See [Google Global Site Tag](/src/lib/providers/gst) if your code snippet contains `gtag.js`
 
 
 ## Contributing

--- a/build.ts
+++ b/build.ts
@@ -14,6 +14,7 @@ const MODULE_NAMES = [
   'ga',
   'ga-enhanced-ecom',
   'gtm',
+  'gst',
   'hubspot',
   'kissmetrics',
   'mixpanel',

--- a/src/app/providers/providers.component.ts
+++ b/src/app/providers/providers.component.ts
@@ -46,6 +46,10 @@ export class ProvidersComponent {
       display: 'Google Tag Manager',
       type: 'Analytics',
     }, {
+      name: 'gst',
+      display: 'Google Global Site Tag',
+      type: 'Analytics',
+    }, {
       name: 'hubspot',
       display: 'HubSpot',
       type: 'Analytics',

--- a/src/lib/core/angulartics2-config.ts
+++ b/src/lib/core/angulartics2-config.ts
@@ -15,6 +15,10 @@ export interface GoogleTagManagerSettings {
   userId: any;
 }
 
+export interface GoogleGlobalSiteTagSettings {
+  trackingIds: any;
+}
+
 export interface PageTrackingSettings {
   autoTrackVirtualPages: boolean;
   basePath: string;
@@ -36,6 +40,7 @@ export interface Angulartics2Settings {
   ga: Partial<GoogleAnalyticsSettings>;
   appInsights: Partial<AppInsightsSettings>;
   gtm: Partial<GoogleTagManagerSettings>;
+  gst: Partial<GoogleGlobalSiteTagSettings>;
 }
 
 export class DefaultConfig implements Angulartics2Settings {
@@ -52,4 +57,5 @@ export class DefaultConfig implements Angulartics2Settings {
   ga = {};
   appInsights = {};
   gtm = {};
+  gst = {};
 }

--- a/src/lib/providers/gst/README.md
+++ b/src/lib/providers/gst/README.md
@@ -1,0 +1,47 @@
+<img 
+    src="../../../assets/svg/gtm.svg" 
+    alt="Google Global Site Tag logo"
+    height="100px"
+    width="200px" />
+
+# Google Global Site Tag (`gtag.js`)
+__homepage__: [google.com/analytics/tag-manager](https://www.google.com/analytics/tag-manager/)  
+docs: [developers.google.com/analytics/devguides/collection/gtagjs](developers.google.com/analytics/devguides/collection/gtagjs)
+__import__: `import { Angulartics2GoogleGlobalSiteTag } from 'angulartics2/gst';`  
+
+
+## Initial Setup
+
+Add the full tracking code from [developers.google.com/analytics/devguides/collection/gtagjs/](developers.google.com/analytics/devguides/collection/gtagjs/)
+
+## Include it in your application
+
+Bootstrapping the application with ```Angulartics2``` as provider and injecting both ```Angulartics2``` and ```Angulartics2GoogleGlobalSiteTag``` (or any provider) into the root component will hook into the router and send every route change to your analytics provider.
+
+
+```ts
+// component
+import { Angulartics2GoogleGlobalSiteTag } from 'angulartics2/gst';
+
+@Component({ ... })
+export class AppComponent {
+  // import Angulartics2GoogleGlobalSiteTag in root component
+  constructor(angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag) {}
+}
+```
+
+```ts
+// bootstrap
+import { Angulartics2Module } from 'angulartics2';
+import { Angulartics2GoogleGlobalSiteTag } from 'angulartics2/gst';
+
+@NgModule({
+  imports: [
+    ...
+    // import Angulartics2GoogleGlobalSiteTag in root ngModule    
+    Angulartics2Module.forRoot([ Angulartics2GoogleGlobalSiteTag ])
+  ],
+})
+```
+
+### _For detailed instructions on how to send tracking events in a component or in a template check out the documentation for [Tracking Events](https://github.com/angulartics/angulartics2/wiki/Tracking-Events)._

--- a/src/lib/providers/gst/gst.spec.ts
+++ b/src/lib/providers/gst/gst.spec.ts
@@ -20,11 +20,11 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
 
     window.gtag = gtag = jasmine.createSpy('gtag');
     window.ga = ga = {
-      getAll: function(){
+      getAll: function() {
         return {
-          forEach: function(callback){
-            var tracker = {
-              get: function(value){
+          forEach: function(callback) {
+            const tracker = {
+              get: function(value) {
                 return 'UA-111111111-1';
               },
             };
@@ -42,7 +42,7 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
         angulartics2.pageTrack.next({ path: '/abc' });
         advance(fixture);
         expect(gtag.calls.count()).toEqual(1);
-        expect(gtag).toHaveBeenCalledWith('config', 'UA-111111111-1', {'page_path': '/abc'})
+        expect(gtag).toHaveBeenCalledWith('config', 'UA-111111111-1', {'page_path': '/abc'});
       },
     )),
   );

--- a/src/lib/providers/gst/gst.spec.ts
+++ b/src/lib/providers/gst/gst.spec.ts
@@ -1,0 +1,97 @@
+import { fakeAsync, inject, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Angulartics2 } from 'angulartics2';
+import { advance, createRoot, RootCmp, TestModule } from '../../test.mocks';
+import { Angulartics2GoogleGlobalSiteTag } from './gst';
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
+declare var window: any;
+
+describe('Angulartics2GoogleGlobalSiteTag', () => {
+  let gtag: any;
+  let ga: any;
+  let fixture: ComponentFixture<any>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestModule],
+      providers: [Angulartics2GoogleGlobalSiteTag],
+    });
+
+    window.gtag = gtag = jasmine.createSpy('gtag');
+    window.ga = ga = {
+      getAll: function(){
+        return {
+          forEach: function(callback){
+            var tracker = {
+              get: function(value){
+                return 'UA-111111111-1';
+              },
+            };
+            callback(tracker);
+          },
+        };
+      },
+    };
+  });
+
+  it('should track pages',
+    fakeAsync(inject([Angulartics2, Angulartics2GoogleGlobalSiteTag],
+      (angulartics2: Angulartics2, angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.pageTrack.next({ path: '/abc' });
+        advance(fixture);
+        expect(gtag.calls.count()).toEqual(1);
+        expect(gtag).toHaveBeenCalledWith('config', 'UA-111111111-1', {'page_path': '/abc'})
+      },
+    )),
+  );
+
+  it('should track events',
+    fakeAsync(inject([Angulartics2, Angulartics2GoogleGlobalSiteTag],
+      (angulartics2: Angulartics2, angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.eventTrack.next({
+          action: 'do',
+          properties: {
+            value: 1,
+            label: 'abc',
+            gstCustom: {
+              customKey: 'customValue',
+            },
+          }
+        });
+        advance(fixture);
+        expect(gtag).toHaveBeenCalledWith('event', 'do', {
+          event_category: 'interaction',
+          event_label: 'abc',
+          value: 1,
+          non_interaction: undefined,
+          customKey: 'customValue',
+        });
+      }
+    )),
+  );
+
+  it('should track exceptions',
+    fakeAsync(inject([Angulartics2, Angulartics2GoogleGlobalSiteTag],
+      (angulartics2: Angulartics2, angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.exceptionTrack.next({ description: 'bugger', gstCustom: { appId: 'app', appName: 'Test App', appVersion: '0.1' } });
+        advance(fixture);
+        expect(gtag).toHaveBeenCalledWith('event', 'exception', {
+          event_category: 'interaction',
+          event_label: undefined,
+          value: undefined,
+          non_interaction: undefined,
+          description: 'bugger',
+          fatal: true,
+          appId: 'app',
+          appName: 'Test App',
+          appVersion: '0.1',
+        });
+      }
+    )),
+  );
+
+});

--- a/src/lib/providers/gst/gst.ts
+++ b/src/lib/providers/gst/gst.ts
@@ -12,7 +12,7 @@ export class GoogleGlobalSiteTagDefaults implements GoogleGlobalSiteTagSettings 
     if (typeof ga !== 'undefined' && ga) {
       // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/ga-object-methods-reference
       ga.getAll().forEach((tracker) => {
-        var id = tracker.get('trackingId');
+        const id = tracker.get('trackingId');
         if (id !== undefined) {
           this.trackingIds.push(id);
         }
@@ -51,8 +51,8 @@ export class Angulartics2GoogleGlobalSiteTag {
    */
   pageTrack(path: string) {
     if (typeof gtag !== 'undefined' && gtag) {
-      for (var i in this.angulartics2.settings.gst.trackingIds) {
-        gtag('config', this.angulartics2.settings.gst.trackingIds[i], {'page_path': path});
+      for (const id of this.angulartics2.settings.gst.trackingIds) {
+        gtag('config', id, {'page_path': path});
       }
     }
   }

--- a/src/lib/providers/gst/gst.ts
+++ b/src/lib/providers/gst/gst.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@angular/core';
+
+import { Angulartics2, GoogleGlobalSiteTagSettings } from 'angulartics2';
+
+declare var gtag: any;
+declare var ga: any;
+
+export class GoogleGlobalSiteTagDefaults implements GoogleGlobalSiteTagSettings {
+  trackingIds = [];
+
+  constructor() {
+    if (typeof ga !== 'undefined' && ga) {
+      // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/ga-object-methods-reference
+      ga.getAll().forEach((tracker) => {
+        var id = tracker.get('trackingId');
+        if (id !== undefined) {
+          this.trackingIds.push(id);
+        }
+      });
+    }
+  }
+}
+
+@Injectable()
+export class Angulartics2GoogleGlobalSiteTag {
+
+  constructor(
+    protected angulartics2: Angulartics2,
+  ) {
+    const defaults = new GoogleGlobalSiteTagDefaults;
+    // Set the default settings for this module
+    this.angulartics2.settings.gst = { ...defaults, ...this.angulartics2.settings.gst };
+
+    this.angulartics2.pageTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.pageTrack(x.path));
+    this.angulartics2.eventTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.eventTrack(x.action, x.properties));
+    this.angulartics2.exceptionTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x: any) => this.exceptionTrack(x));
+  }
+
+  /**
+   * Manually track page view, see:
+   *
+   * https://developers.google.com/analytics/devguides/collection/gtagjs/single-page-applications#tracking_virtual_pageviews
+   *
+   * @param path relative url
+   */
+  pageTrack(path: string) {
+    if (typeof gtag !== 'undefined' && gtag) {
+      for (var i in this.angulartics2.settings.gst.trackingIds) {
+        gtag('config', this.angulartics2.settings.gst.trackingIds[i], {'page_path': path});
+      }
+    }
+  }
+
+  /**
+   * Send interactions to gtag, i.e. for event tracking in Google Analytics. See:
+   *
+   * https://developers.google.com/analytics/devguides/collection/gtagjs/events
+   *
+   * @param action associated with the event
+   */
+  eventTrack(action: string, properties: any) {
+    // TODO: make interface
+    //  @param {string} properties.category
+    //  @param {string} [properties.label]
+    //  @param {number} [properties.value]
+    //  @param {boolean} [properties.noninteraction]
+    // Set a default GST category
+    properties = properties || {};
+
+    if (typeof gtag !== 'undefined' && gtag) {
+      gtag('event', action, {
+        event_category: properties.category || 'interaction',
+        event_label: properties.label,
+        value: properties.value,
+        non_interaction: properties.noninteraction,
+        ...properties.gstCustom
+      });
+    }
+  }
+
+  /**
+   * Exception Track Event in GST. See:
+   *
+   * https://developers.google.com/analytics/devguides/collection/gtagjs/exceptions
+   *
+   */
+  exceptionTrack(properties: any) {
+    // TODO: make interface
+    //  @param {Object} properties
+    //  @param {string} [properties.description]
+    //  @param {boolean} [properties.fatal]
+    if (properties.fatal === undefined) {
+      console.log('No "fatal" provided, sending with fatal=true');
+      properties.fatal = true;
+    }
+
+    properties.exDescription = properties.event ? properties.event.stack : properties.description;
+
+    this.eventTrack('exception', {
+      gstCustom: {
+        'description': properties.exDescription,
+        'fatal': properties.fatal,
+        ...properties.gstCustom
+      }
+    });
+  }
+}

--- a/src/lib/providers/gst/package.json
+++ b/src/lib/providers/gst/package.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/package.schema.json",
+  "name": "angulartics2/gst",
+  "description": "The gst module",
+  "homepage": "https://angulartics.github.io/angulartics2/",
+  "author": "Adrian Duke <adrian@endian.io> (http://github.com/adrianduke)",
+  "repository": "angulartics/angulartics2",
+  "license": "MIT",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "gst.ts",
+      "umdModuleIds": {
+        "angulartics2": "angulartics2"
+      }
+    },
+    "dest": "../../../../dist/packages-dist/gst"
+  }
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
New provider to support Google Analytics new default tracker Global Site Tag

- **What is the current behavior? Link to open issue?**
#272 #155

- **What is the new behavior?**
Replica of the GTM module sans the `userID` method. Supports Page View, Custom Events and Exceptions.