### PR TITLE
fix(gst): Ensure GST is loaded in before running ga.getAll

### DIFF
--- a/src/lib/providers/gst/gst.spec.ts
+++ b/src/lib/providers/gst/gst.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, inject, TestBed } from '@angular/core/testing';
+import { fakeAsync, inject, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Angulartics2 } from 'angulartics2';
 import { advance, createRoot, RootCmp, TestModule } from '../../test.mocks';
 import { Angulartics2GoogleGlobalSiteTag } from './gst';

--- a/src/lib/providers/gst/gst.spec.ts
+++ b/src/lib/providers/gst/gst.spec.ts
@@ -1,8 +1,8 @@
-import { fakeAsync, inject, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, fakeAsync, inject, TestBed } from '@angular/core/testing';
 import { Angulartics2 } from 'angulartics2';
 import { advance, createRoot, RootCmp, TestModule } from '../../test.mocks';
 import { Angulartics2GoogleGlobalSiteTag } from './gst';
+
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
 declare var window: any;
@@ -19,19 +19,20 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
     });
 
     window.gtag = gtag = jasmine.createSpy('gtag');
-    window.ga = ga = {
-      getAll: function() {
-        return {
-          forEach: function(callback) {
-            const tracker = {
-              get: function(value) {
-                return 'UA-111111111-1';
-              },
-            };
-            callback(tracker);
-          },
-        };
-      },
+    window.ga = ga = function (callback) {
+      callback();
+    };
+    window.ga.getAll = ga.getAll = function () {
+      return {
+        forEach: function (callback) {
+          const tracker = {
+            get: function (value) {
+              return 'UA-111111111-1';
+            },
+          };
+          callback(tracker);
+        },
+      };
     };
   });
 
@@ -42,7 +43,7 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
         angulartics2.pageTrack.next({ path: '/abc' });
         advance(fixture);
         expect(gtag.calls.count()).toEqual(1);
-        expect(gtag).toHaveBeenCalledWith('config', 'UA-111111111-1', {'page_path': '/abc'});
+        expect(gtag).toHaveBeenCalledWith('config', 'UA-111111111-1', { 'page_path': '/abc' });
       },
     )),
   );

--- a/src/lib/providers/gst/gst.ts
+++ b/src/lib/providers/gst/gst.ts
@@ -11,11 +11,13 @@ export class GoogleGlobalSiteTagDefaults implements GoogleGlobalSiteTagSettings 
   constructor() {
     if (typeof ga !== 'undefined' && ga) {
       // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/ga-object-methods-reference
-      ga.getAll().forEach((tracker) => {
-        const id = tracker.get('trackingId');
-        if (id !== undefined) {
-          this.trackingIds.push(id);
-        }
+      ga(() => {
+        ga.getAll().forEach((tracker) => {
+          const id = tracker.get('trackingId');
+          if (id !== undefined) {
+            this.trackingIds.push(id);
+          }
+        });
       });
     }
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Fixes a bug where tracking blockers and asynchronous site tag loading could cause an Angular-crashing error

- **What is the current behavior? Link to open issue?**
As described in #298, `ga.getAll` is run even when Analytics isn't loaded in, which can happen if the user has a tracking blocker installed or the script is just running slow.

- **What is the new behavior?**
Uses the documented wrapper from Google to ensure the code is run after GA is loaded.