### PR TITLE
feat: add trackSiteSearch event to Piwik provider

### DIFF
--- a/src/lib/providers/piwik/piwik.spec.ts
+++ b/src/lib/providers/piwik/piwik.spec.ts
@@ -152,6 +152,29 @@ describe('Angulartics2Piwik', () => {
       )),
     );
 
+    it('should track search',
+      fakeAsync(inject([Angulartics2, Angulartics2Piwik],
+        (angulartics2: Angulartics2, angulartics2Piwik: Angulartics2Piwik) => {
+          fixture = createRoot(RootCmp);
+
+          const search = {
+            keyword: 'my search string',
+            category: 'my search category',
+            searchCount: 42,
+          };
+
+          angulartics2.eventTrack.next({action: 'trackSiteSearch', properties: search});
+          advance(fixture);
+
+          expect(_paq).toContain(['trackSiteSearch',
+            search.keyword,
+            search.category,
+            search.searchCount,
+          ]);
+        }
+      )),
+    );
+
     it('should track events', fakeAsync(inject([Angulartics2, Angulartics2Piwik],
       (angulartics2: Angulartics2, angulartics2Piwik: Angulartics2Piwik) => {
         fixture = createRoot(RootCmp);

--- a/src/lib/providers/piwik/piwik.ts
+++ b/src/lib/providers/piwik/piwik.ts
@@ -150,6 +150,25 @@ export class Angulartics2Piwik {
         break;
 
       /**
+       * @description Tracks a site search
+       *
+       * @link https://piwik.org/docs/site-search/
+       * @link https://developer.piwik.org/guides/tracking-javascript-guide#internal-search-tracking
+       *
+       * @property keyword (required) Keyword searched for
+       * @property category (optional) Search category
+       * @property searchCount (optional) Number of results
+       */
+      case 'trackSiteSearch':
+        params = [
+          'trackSiteSearch',
+          properties.keyword,
+          properties.category,
+          properties.searchCount,
+        ];
+        break;
+
+      /**
        * @description Logs an event with an event category (Videos, Music, Games...), an event
        * action (Play, Pause, Duration, Add Playlist, Downloaded, Clicked...), and an optional
        * event name and optional numeric value.


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Add support for tracking site search requests using Piwik provider.

- **What is the current behavior? Link to open issue?**
No support for trackSiteSearch event.

- **What is the new behavior?**
Site search request can be tracked using eventTrack.
