### PR TITLE
feat: add provider Launch, by Adobe

### DIFF
--- a/src/lib/providers/launch/README.md
+++ b/src/lib/providers/launch/README.md
@@ -48,22 +48,6 @@ import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';
 })
 ```
 
-## Configuration
-
-The Provider translates Angulartics' ```pageTrack()``` and ```eventTrack()``` methods into ```_satellite.track()``` calls for Launch. Those calls trigger "Direct-call" events within Launch.
-
-You can configure the ID of the events that should be called.
-
-The default IDs can be seen in ```launch.ts```:
-```ts
-// define DCR IDs for the available call types
-dcrIDs = {};
-dcrIDs['pageTrack'] = 'pageTrack';
-dcrIDs['eventTrack'] = 'eventTrack';
-```
-With the default configuration as shown, a ```pageTrack()``` method call in Angulartics2 will result in a call to Launch that looks like this: ```_satellite.track('pageTrack', payload)```, triggering a 'pageTrack' Direct-call type Event if there is one configured. This Event, in turn, can trigger one or more Rules.
-
-
 ## Setting Up Tags
 
 Once set up, Angulartics [usage](https://github.com/angulartics/angulartics2#usage) is the same regardless of provider

--- a/src/lib/providers/launch/README.md
+++ b/src/lib/providers/launch/README.md
@@ -12,7 +12,9 @@ __import__: `import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';`
 
 ## Initial Setup
 
-Add your Launch embed code to the end of your head tag.
+Add your Launch embed code to the end of your head tag, as usual.
+
+You can either add just the embed code with "async", or non-async embed code in the head plus the <code>_satellite.pageBottom()</code> snippet at the end of the body.
 
 ## Include it in your application
 
@@ -48,6 +50,8 @@ import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';
 
 ### Setting Up Tags
 
+Once set up, Angulartics [usage](https://github.com/angulartics/angulartics2#usage) is the same regardless of provider
+
 Now is the time to setup tracking in Launch.  [Here is a great post](http://webanalyticsfordevelopers.com/2018/11/06/basic-tracking-remix-contains-launch/) explaining how a basic tracking setup can be done.
 
-### _For detailed instructions on how to send tracking events in a component or in a template check out the documentation for [Tracking Events](https://github.com/angulartics/angulartics2/wiki/Tracking-Events)._
+_For detailed instructions on how to send tracking events in a component or in a template check out the documentation for [Tracking Events](https://github.com/angulartics/angulartics2/wiki/Tracking-Events)._

--- a/src/lib/providers/launch/README.md
+++ b/src/lib/providers/launch/README.md
@@ -1,0 +1,53 @@
+<img 
+    src="https://developer.adobelaunch.com/images/launch.svg" 
+    alt="Launch, by Adobe logo"
+    height="100px"
+    width="100px" />
+
+# Launch, by Adobe
+__homepage__: [Launch, by Adobe](https://www.adobe.com/experience-platform/launch.html)  
+__docs__: [developer.adobelaunch.com/](https://developer.adobelaunch.com/)  
+__import__: `import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';`  
+
+
+## Initial Setup
+
+Add your Launch embed code to the end of your head tag.
+
+## Include it in your application
+
+Bootstrapping the application with ```Angulartics2``` as provider and injecting both ```Angulartics2``` and ```Angulartics2LaunchByAdobe``` (or any provider) into the root component will hook into the router and send every route change to Launch, where it can be used for Analytics tracking or a lot of other things.
+
+
+```ts
+// component
+import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';
+
+@Component({ ... })
+export class AppComponent {
+  // import Angulartics2LaunchByAdobe in root component
+  constructor(angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) {
+    angulartics2LaunchByAdobe.startTracking();
+  }
+}
+```
+
+```ts
+// bootstrap
+import { Angulartics2Module } from 'angulartics2';
+import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';
+
+@NgModule({
+  imports: [
+    ...
+    // import Angulartics2LaunchByAdobe in root ngModule    
+    Angulartics2Module.forRoot([ Angulartics2LaunchByAdobe ])
+  ],
+})
+```
+
+### Setting Up Tags
+
+Now is the time to setup tracking in Launch.  [Here is a great post](http://webanalyticsfordevelopers.com/2018/11/06/basic-tracking-remix-contains-launch/) explaining how a basic tracking setup can be done.
+
+### _For detailed instructions on how to send tracking events in a component or in a template check out the documentation for [Tracking Events](https://github.com/angulartics/angulartics2/wiki/Tracking-Events)._

--- a/src/lib/providers/launch/README.md
+++ b/src/lib/providers/launch/README.md
@@ -48,10 +48,26 @@ import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';
 })
 ```
 
-### Setting Up Tags
+## Configuration
+
+The Provider translates Angulartics' ```pageTrack()``` and ```eventTrack()``` methods into ```_satellite.track()``` calls for Launch. Those calls trigger "Direct-call" events within Launch.
+
+You can configure the ID of the events that should be called.
+
+The default IDs can be seen in ```launch.ts```:
+```ts
+// define DCR IDs for the available call types
+dcrIDs = {};
+dcrIDs['pageTrack'] = 'pageTrack';
+dcrIDs['eventTrack'] = 'eventTrack';
+```
+With the default configuration as shown, a ```pageTrack()``` method call in Angulartics2 will result in a call to Launch that looks like this: ```_satellite.track('pageTrack', payload)```, triggering a 'pageTrack' Direct-call type Event if there is one configured. This Event, in turn, can trigger one or more Rules.
+
+
+## Setting Up Tags
 
 Once set up, Angulartics [usage](https://github.com/angulartics/angulartics2#usage) is the same regardless of provider
 
-Now is the time to setup tracking in Launch.  [Here is a great post](http://webanalyticsfordevelopers.com/2018/11/06/basic-tracking-remix-contains-launch/) explaining how a basic tracking setup can be done.
+Now is the time to setup tracking in Launch.  [Here is a post](http://webanalyticsfordevelopers.com/2018/11/06/basic-tracking-remix-contains-launch/) explaining how a basic tracking setup can be done.
 
 _For detailed instructions on how to send tracking events in a component or in a template check out the documentation for [Tracking Events](https://github.com/angulartics/angulartics2/wiki/Tracking-Events)._

--- a/src/lib/providers/launch/launch.spec.ts
+++ b/src/lib/providers/launch/launch.spec.ts
@@ -31,44 +31,29 @@ describe('Angulartics2LaunchByAdobe', () => {
 
   it('should track pages',
     fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
-      (angulartics2: Angulartics2, angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
+      (angulartics2: Angulartics2) => {
         fixture = createRoot(RootCmp);
         angulartics2.pageTrack.next({ path: '/abc' });
         advance(fixture);
-        expect(_satellite.output).toContain({
-          'eventID': 'pageTrack',
-          'payload': '/abc'
-        });
+        expect(Object.keys(_satellite.output)).toEqual(['eventID', 'payload']);
+        expect(_satellite.output.eventID).toEqual('pageTrack');
+        expect(_satellite.output.payload).toEqual('/abc');
       }
     )),
   );
 
   it('should track events',
     fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
-      (angulartics2: Angulartics2, angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
+      (angulartics2: Angulartics2) => {
         fixture = createRoot(RootCmp);
         angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
         advance(fixture);
-        expect(_satellite.output).toContain({
-          'eventID': 'eventTrack',
-          'payload': {
-            'action': 'do',
-            'eventProperties': {
-              'category': 'cat'
-            }
-          }
-        });
-      }
-    )),
-  );
-
-  it('should set username',
-    fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
-      (angulartics2: Angulartics2, angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
-        fixture = createRoot(RootCmp);
-        angulartics2.setUsername.next('testuser');
-        advance(fixture);
-        expect(angulartics2.settings.gtm.userId).toBe('testuser');
+        expect(Object.keys(_satellite.output)).toEqual(['eventID', 'payload']);
+        expect(_satellite.output.eventID).toEqual('eventTrack');
+        expect(Object.keys(_satellite.output.payload)).toEqual(['action', 'eventProperties']);
+        expect(_satellite.output.payload.action).toEqual('do');
+        expect(Object.keys(_satellite.output.payload.eventProperties)).toEqual(['category']);
+        expect(_satellite.output.payload.eventProperties.category).toEqual('cat');
       }
     )),
   );

--- a/src/lib/providers/launch/launch.spec.ts
+++ b/src/lib/providers/launch/launch.spec.ts
@@ -20,9 +20,9 @@ describe('Angulartics2LaunchByAdobe', () => {
     window._satellite = _satellite = {};
     _satellite.track = function(eventID: String, payload: any) {
       _satellite.output = {
-        "eventID" : eventID,
-        "payload": payload
-      }
+        'eventID' : eventID,
+        'payload': payload
+      };
     };
     _satellite.output = null;
     const provider: Angulartics2LaunchByAdobe = TestBed.get(Angulartics2LaunchByAdobe);
@@ -31,30 +31,30 @@ describe('Angulartics2LaunchByAdobe', () => {
 
   it('should track pages',
     fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
-      (angulartics2: Angulartics2, Angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
+      (angulartics2: Angulartics2, angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
         fixture = createRoot(RootCmp);
         angulartics2.pageTrack.next({ path: '/abc' });
         advance(fixture);
         expect(_satellite.output).toContain({
-          "eventID": 'pageTrack',
-          "payload": '/abc'
+          'eventID': 'pageTrack',
+          'payload': '/abc'
         });
-      },
+      }
     )),
   );
 
   it('should track events',
     fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
-      (angulartics2: Angulartics2, Angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
+      (angulartics2: Angulartics2, angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
         fixture = createRoot(RootCmp);
         angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
         advance(fixture);
         expect(_satellite.output).toContain({
-          "eventID": 'eventTrack',
-          "payload": {
-            "action": 'do',
-            "eventProperties": {
-              "category": 'cat'
+          'eventID': 'eventTrack',
+          'payload': {
+            'action': 'do',
+            'eventProperties': {
+              'category': 'cat'
             }
           }
         });
@@ -64,7 +64,7 @@ describe('Angulartics2LaunchByAdobe', () => {
 
   it('should set username',
     fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
-      (angulartics2: Angulartics2, Angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
+      (angulartics2: Angulartics2, angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
         fixture = createRoot(RootCmp);
         angulartics2.setUsername.next('testuser');
         advance(fixture);

--- a/src/lib/providers/launch/launch.spec.ts
+++ b/src/lib/providers/launch/launch.spec.ts
@@ -1,0 +1,76 @@
+import { fakeAsync, inject, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Angulartics2 } from 'angulartics2';
+import { advance, createRoot, RootCmp, TestModule } from '../../test.mocks';
+import { Angulartics2LaunchByAdobe } from './launch';
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
+declare var window: any;
+
+describe('Angulartics2LaunchByAdobe', () => {
+  let _satellite: any;
+  let fixture: ComponentFixture<any>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestModule],
+      providers: [Angulartics2LaunchByAdobe],
+    });
+
+    window._satellite = _satellite = {};
+    _satellite.track = function(eventID: String, payload: any) {
+      _satellite.output = {
+        "eventID" : eventID,
+        "payload": payload
+      }
+    };
+    _satellite.output = null;
+    const provider: Angulartics2LaunchByAdobe = TestBed.get(Angulartics2LaunchByAdobe);
+    provider.startTracking();
+  });
+
+  it('should track pages',
+    fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
+      (angulartics2: Angulartics2, Angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.pageTrack.next({ path: '/abc' });
+        advance(fixture);
+        expect(_satellite.output).toContain({
+          "eventID": 'pageTrack',
+          "payload": '/abc'
+        });
+      },
+    )),
+  );
+
+  it('should track events',
+    fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
+      (angulartics2: Angulartics2, Angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
+        advance(fixture);
+        expect(_satellite.output).toContain({
+          "eventID": 'eventTrack',
+          "payload": {
+            "action": 'do',
+            "eventProperties": {
+              "category": 'cat'
+            }
+          }
+        });
+      }
+    )),
+  );
+
+  it('should set username',
+    fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
+      (angulartics2: Angulartics2, Angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.setUsername.next('testuser');
+        advance(fixture);
+        expect(angulartics2.settings.gtm.userId).toBe('testuser');
+      }
+    )),
+  );
+
+});

--- a/src/lib/providers/launch/launch.ts
+++ b/src/lib/providers/launch/launch.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Angulartics2 } from 'angulartics2';
 
 export interface Angulartics2LaunchByAdobeDCRIDMap {
-  [details: string] : string;
+  [details: string]: string;
 }
 
 declare const _satellite: any;
@@ -16,11 +16,11 @@ export class Angulartics2LaunchByAdobe {
   constructor(
     protected angulartics2: Angulartics2,
   ) {
-    // define DCR IDs for the three call types
+    // define DCR IDs for the available call types
     dcrIDs = {};
     dcrIDs['pageTrack'] = 'pageTrack';
     dcrIDs['eventTrack'] = 'eventTrack';
-    if (typeof _satellite === 'undefined') {
+    if ('undefined' === typeof _satellite) {
       console.warn('Launch not found!');
     }
     this.angulartics2.setUsername

--- a/src/lib/providers/launch/launch.ts
+++ b/src/lib/providers/launch/launch.ts
@@ -2,24 +2,14 @@ import { Injectable } from '@angular/core';
 
 import { Angulartics2 } from 'angulartics2';
 
-export interface Angulartics2LaunchByAdobeDCRIDMap {
-  [details: string]: string;
-}
-
 declare const _satellite: any;
-declare var payload: any;
-declare var dcrIDs: Angulartics2LaunchByAdobeDCRIDMap;
 
 @Injectable({ providedIn: 'root' })
 export class Angulartics2LaunchByAdobe {
-
+  payload: any = {};
   constructor(
     protected angulartics2: Angulartics2,
   ) {
-    // define DCR IDs for the available call types
-    dcrIDs = {};
-    dcrIDs['pageTrack'] = 'pageTrack';
-    dcrIDs['eventTrack'] = 'eventTrack';
     if ('undefined' === typeof _satellite) {
       console.warn('Launch not found!');
     }
@@ -31,15 +21,13 @@ export class Angulartics2LaunchByAdobe {
 
   setUsername(userId: string | boolean) {
     if ('undefined' !== typeof userId && userId) {
-      payload = payload || {};
-      payload.userId = userId;
+      this.payload.userId = userId;
     }
   }
 
   setUserProperties(properties: any) {
     if ('undefined' !== typeof properties && properties) {
-      payload = payload || {};
-      payload.properties = properties;
+      this.payload.properties = properties;
     }
   }
 
@@ -54,7 +42,7 @@ export class Angulartics2LaunchByAdobe {
 
   pageTrack(path: string) {
     if ('undefined' !== typeof _satellite && _satellite) {
-      _satellite.track(dcrIDs['pageTrack'], path);
+      _satellite.track('pageTrack', path);
     }
   }
 
@@ -66,12 +54,11 @@ export class Angulartics2LaunchByAdobe {
     properties = properties || {};
 
     // add properties to payload
-    payload = payload || {};
-    payload.action = action;
-    payload.eventProperties = properties;
+    this.payload.action = action;
+    this.payload.eventProperties = properties;
 
     if ('undefined' !== typeof _satellite && _satellite) {
-      _satellite.track(dcrIDs['eventTrack'], payload);
+      _satellite.track('eventTrack', this.payload);
     }
   }
 }

--- a/src/lib/providers/launch/launch.ts
+++ b/src/lib/providers/launch/launch.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+
+import { Angulartics2 } from 'angulartics2';
+
+export interface Angulartics2LaunchByAdobeDCRIDMap {
+  [details: string] : string;
+}
+
+declare const _satellite: any;
+declare var payload: any;
+declare var dcrIDs: Angulartics2LaunchByAdobeDCRIDMap;
+
+@Injectable({ providedIn: 'root' })
+export class Angulartics2LaunchByAdobe {
+
+  constructor(
+    protected angulartics2: Angulartics2,
+  ) {
+    // define DCR IDs for the three call types
+    dcrIDs = {};
+    dcrIDs['pageTrack'] = 'pageTrack';
+    dcrIDs['eventTrack'] = 'eventTrack';
+    if (typeof _satellite === 'undefined') {
+      console.warn('Launch not found!');
+    }
+    this.angulartics2.setUsername
+      .subscribe((x: string) => this.setUsername(x));
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+  }
+
+  setUsername(userId: string | boolean) {
+    if ('undefined' !== typeof userId && userId) {
+      payload = payload || {};
+      payload.userId = userId;
+    }
+  }
+
+  setUserProperties(properties: any) {
+    if ('undefined' !== typeof properties && properties) {
+      payload = payload || {};
+      payload.properties = properties;
+    }
+  }
+
+  startTracking() {
+    this.angulartics2.pageTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.pageTrack(x.path));
+    this.angulartics2.eventTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.eventTrack(x.action, x.properties));
+  }
+
+  pageTrack(path: string) {
+    if ('undefined' !== typeof _satellite && _satellite) {
+      _satellite.track(dcrIDs['pageTrack'], path);
+    }
+  }
+
+  /**
+   * @param action associated with the event
+   * @param properties associated with the event
+   */
+  eventTrack(action: string, properties: any) {
+    properties = properties || {};
+
+    // add properties to payload
+    payload = payload || {};
+    payload.action = action;
+    payload.eventProperties = properties;
+
+    if ('undefined' !== typeof _satellite && _satellite) {
+      _satellite.track(dcrIDs['eventTrack'], payload);
+    }
+  }
+}

--- a/src/lib/providers/launch/package.json
+++ b/src/lib/providers/launch/package.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/package.schema.json",
+  "name": "angulartics2/launch",
+  "description": "The Launch module",
+  "homepage": "https://angulartics.github.io/angulartics2/",
+  "author": "Jan Exner <jan.exner@gmx.net> (https://github.com/janexner)",
+  "repository": "angulartics/angulartics2",
+  "license": "MIT",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "launch.ts",
+      "umdModuleIds": {
+        "angulartics2": "angulartics2"
+      }
+    },
+    "dest": "../../../../dist/packages-dist/launch"
+  }
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Added a provider for the recent Tag Managemener Launch, by Adobe

- **What is the current behavior? Link to open issue?**
No provider available for Launch, by Adobe

- **What is the new behavior?**
Provider for Launch, by Adobe, can handle pageTrack and eventTrack.