### PR TITLE
fix(GTM): Fixed error given by data layer server-side

### DIFF
--- a/src/lib/providers/gtm/gtm.ts
+++ b/src/lib/providers/gtm/gtm.ts
@@ -51,11 +51,9 @@ export class Angulartics2GoogleTagManager {
    * @layer data layer object
    */
   pushLayer(layer: any) {
-    if (typeof dataLayer === 'undefined' && !dataLayer) {
-      return;
+    if (typeof dataLayer !== 'undefined' && dataLayer) {
+      dataLayer.push(layer);
     }
-
-    dataLayer.push(layer);
   }
 
   /**


### PR DESCRIPTION
The last change created an error while rendering an app using server-side rendering

```
ERROR ReferenceError: dataLayer is not defined
    at Angulartics2GoogleTagManager.pushLayer
```

This caused the error

```
if (typeof dataLayer === 'undefined' && !dataLayer) {
            return;
        }
```

On the server, data layer is undefined (first condition true) so the second gives an error

