### PR TITLE
fix(launch): Send Properties to Launch on pageTrack

### DIFF
--- a/src/lib/providers/launch/launch.ts
+++ b/src/lib/providers/launch/launch.ts
@@ -41,8 +41,11 @@ export class Angulartics2LaunchByAdobe {
   }
 
   pageTrack(path: string) {
+    this.payload = this.payload || {};
+    this.payload.path = path;
+
     if ('undefined' !== typeof _satellite && _satellite) {
-      _satellite.track('pageTrack', path);
+      _satellite.track('pageTrack', this.payload);
     }
   }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Send Properties to Launch on pageTrack

- **What is the current behavior? Link to open issue?**
Currently, only eventTrack sends properties

- **What is the new behavior?**
Send Properties to Launch on pageTrack