### PR TITLE
feat(GST): GST provider larger support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log
 # System Files
 .DS_Store
 Thumbs.db
+.history/

--- a/src/lib/core/angulartics2-config.ts
+++ b/src/lib/core/angulartics2-config.ts
@@ -17,6 +17,9 @@ export interface GoogleTagManagerSettings {
 
 export interface GoogleGlobalSiteTagSettings {
   trackingIds: any;
+  userId?: any;
+  anonymizeIp?: boolean;
+  customMap?: { [key: string]: string };
 }
 
 export interface PageTrackingSettings {

--- a/src/lib/providers/gst/README.md
+++ b/src/lib/providers/gst/README.md
@@ -49,6 +49,58 @@ export class AppComponent {
 }
 ```
 
+### Custom dimension
+
+`custom_map` you could set inside your HTML page will be overridden after each pagetrack. Therefore, you need to pass them to the GST configuration if you want to use them. At this point, you're probably better to remove completely the `gtag('config'` call from you HTML page and to add all required properties at module definition.
+
+```ts
+// bootstrap
+import { Angulartics2Module } from 'angulartics2';
+
+@NgModule({
+  imports: [
+    ...
+    // import Angulartics2GoogleGlobalSiteTag in root ngModule
+    Angulartics2Module.forRoot(
+      gst: {
+        trackingIds: ['UA-11111111-1'],
+        customMap: {
+          dimension1: 'version',
+          dimension2: 'page_language',
+          dimension3: 'custom_dimension_name'
+        },
+        anonymizeIp: true
+      },
+    )
+  ],
+})
+export class AppModule { }
+```
+
+Then, you can user the normal angulartic approach:
+
+```
+this.angulartics2.setUserProperties.next({
+  custom_dimension_name: 'example'
+});
+```
+
+You can also pass custom dimension with a specific event using the `gstCustom` property
+
+```
+constructor(private angulartics2: Angulartics2) {
+  this.angulartics2.eventTrack.next({ 
+    action: 'myAction', 
+    properties: {
+      category: 'myCategory'
+      gstCustom: {
+        custom_dimension_name: 'example'
+      }
+    },
+  });
+}
+```
+
 ### Send tracking events in a component or template
 
 _Check out the documentation for [Tracking Events](https://github.com/angulartics/angulartics2/wiki/Tracking-Events)._

--- a/src/lib/providers/gst/gst-interfaces.ts
+++ b/src/lib/providers/gst/gst-interfaces.ts
@@ -9,3 +9,11 @@ export interface UserTimingsGst {
   /** A string that can be used to add flexibility in visualizing user timings in the reports (e.g. 'Google CDN'). */
   label?: string;
 }
+
+export interface EventGst {
+  category: string;
+  label?: string;
+  value?: number | string;
+  noninteraction?: boolean;
+  gstCustom?: any;
+}

--- a/src/lib/providers/gst/gst.spec.ts
+++ b/src/lib/providers/gst/gst.spec.ts
@@ -286,7 +286,7 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
       angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
     ) => {
       window.gtag = undefined;
-      window.ga = undefined
+      window.ga = undefined;
 
       fixture = createRoot(RootCmp);
       angulartics2GoogleGlobalSiteTag.startTracking();

--- a/src/lib/providers/gst/gst.spec.ts
+++ b/src/lib/providers/gst/gst.spec.ts
@@ -23,14 +23,14 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
     });
 
     window.gtag = gtag = jasmine.createSpy('gtag');
-    window.ga = ga = function(callback) {
+    window.ga = ga = function (callback) {
       callback();
     };
-    window.ga.getAll = ga.getAll = function() {
+    window.ga.getAll = ga.getAll = function () {
       return {
-        forEach: function(callback) {
+        forEach: function (callback) {
           const tracker = {
-            get: function(value) {
+            get: function (value) {
               return 'UA-111111111-1';
             },
           };
@@ -91,28 +91,28 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
 
   it('should track exceptions', fakeAsync(
     inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
-        angulartics2: Angulartics2,
-        angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
-      ) => {
-        fixture = createRoot(RootCmp);
-        angulartics2GoogleGlobalSiteTag.startTracking();
-        angulartics2.exceptionTrack.next({
-          description: 'bugger',
-          gstCustom: { appId: 'app', appName: 'Test App', appVersion: '0.1' },
-        });
-        advance(fixture);
-        expect(gtag).toHaveBeenCalledWith('event', 'exception', {
-          event_category: 'interaction',
-          event_label: undefined,
-          value: undefined,
-          non_interaction: undefined,
-          description: 'bugger',
-          fatal: true,
-          appId: 'app',
-          appName: 'Test App',
-          appVersion: '0.1',
-        });
-      },
+      angulartics2: Angulartics2,
+      angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
+    ) => {
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.exceptionTrack.next({
+        description: 'bugger',
+        gstCustom: { appId: 'app', appName: 'Test App', appVersion: '0.1' },
+      });
+      advance(fixture);
+      expect(gtag).toHaveBeenCalledWith('event', 'exception', {
+        event_category: 'interaction',
+        event_label: undefined,
+        value: undefined,
+        non_interaction: undefined,
+        description: 'bugger',
+        fatal: true,
+        appId: 'app',
+        appName: 'Test App',
+        appVersion: '0.1',
+      });
+    },
     ),
   ));
 
@@ -120,23 +120,23 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
     inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
       angulartics2: Angulartics2,
       angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
-      ) => {
-        fixture = createRoot(RootCmp);
-        angulartics2GoogleGlobalSiteTag.startTracking();
-        angulartics2.userTimings.next({
-          timingVar: 'load',
-          timingValue: 33,
-          timingCategory: 'JS Dependencies',
-          timingLabel: 'Google CDN'
-        });
-        advance(fixture);
-        expect(gtag).toHaveBeenCalledWith('event', 'timing_complete', {
-          name: 'load',
-          value: 33,
-          event_category: 'JS Dependencies',
-          event_label: 'Google CDN'
-        });
-      },
+    ) => {
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.userTimings.next({
+        timingVar: 'load',
+        timingValue: 33,
+        timingCategory: 'JS Dependencies',
+        timingLabel: 'Google CDN'
+      });
+      advance(fixture);
+      expect(gtag).toHaveBeenCalledWith('event', 'timing_complete', {
+        name: 'load',
+        value: 33,
+        event_category: 'JS Dependencies',
+        event_label: 'Google CDN'
+      });
+    },
     ),
   ));
 
@@ -144,18 +144,18 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
     inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
       angulartics2: Angulartics2,
       angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
-      ) => {
-        fixture = createRoot(RootCmp);
-        angulartics2GoogleGlobalSiteTag.startTracking();
-        angulartics2.setUserProperties.next({
-          'custom_dimension': 'some value'
-        });
-        advance(fixture);
-        expect(gtag.calls.count()).toEqual(1);
-        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
-          'custom_dimension': 'some value'
-        });
-      },
+    ) => {
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.setUserProperties.next({
+        'custom_dimension': 'some value'
+      });
+      advance(fixture);
+      expect(gtag.calls.count()).toEqual(1);
+      expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
+        'custom_dimension': 'some value'
+      });
+    },
     ),
   ));
 
@@ -163,22 +163,22 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
     inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
       angulartics2: Angulartics2,
       angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
-      ) => {
-        fixture = createRoot(RootCmp);
-        angulartics2GoogleGlobalSiteTag.startTracking();
-        angulartics2.setUserProperties.next({
-          'custom_dimension': 'some value'
-        });
-        angulartics2.setUserProperties.next({
-          'other_dimension': 'other value'
-        });
-        advance(fixture);
-        expect(gtag.calls.count()).toEqual(2);
-        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
-          'custom_dimension': 'some value',
-          'other_dimension': 'other value'
-        });
-      },
+    ) => {
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.setUserProperties.next({
+        'custom_dimension': 'some value'
+      });
+      angulartics2.setUserProperties.next({
+        'other_dimension': 'other value'
+      });
+      advance(fixture);
+      expect(gtag.calls.count()).toEqual(2);
+      expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
+        'custom_dimension': 'some value',
+        'other_dimension': 'other value'
+      });
+    },
     ),
   ));
 
@@ -186,36 +186,60 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
     inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
       angulartics2: Angulartics2,
       angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
-      ) => {
-        fixture = createRoot(RootCmp);
-        angulartics2GoogleGlobalSiteTag.startTracking();
-        angulartics2.setUserProperties.next({
-          'custom_dimension': 'some value'
-        });
-        angulartics2.setUserProperties.next({
-          'custom_dimension': undefined
-        });
-        advance(fixture);
-        expect(gtag.calls.count()).toEqual(2);
-        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {});
-      },
+    ) => {
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.setUserProperties.next({
+        'custom_dimension': 'some value'
+      });
+      angulartics2.setUserProperties.next({
+        'custom_dimension': undefined
+      });
+      advance(fixture);
+      expect(gtag.calls.count()).toEqual(2);
+      expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {});
+    },
     ),
+  ));
+
+  it('string value should be transformed into integer', fakeAsync(
+    inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
+      angulartics2: Angulartics2,
+      angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
+    ) => {
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.eventTrack.next({
+        action: 'loading',
+        properties: {
+          value: '34.5'
+        }
+      });
+      advance(fixture);
+      expect(gtag.calls.count()).toEqual(1);
+      expect(gtag).toHaveBeenCalledWith('event', 'loading', {
+        event_category: 'interaction',
+        value: 34,
+        event_label: undefined,
+        non_interaction: undefined
+      });
+    })
   ));
 
   it('should set user id, by string', fakeAsync(
     inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
       angulartics2: Angulartics2,
       angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
-      ) => {
-        fixture = createRoot(RootCmp);
-        angulartics2GoogleGlobalSiteTag.startTracking();
-        angulartics2.setUsername.next('90a72f4f-f0ee-43ac-802e-2e30a1741183');
-        advance(fixture);
-        expect(gtag.calls.count()).toEqual(1);
-        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
-          user_id: '90a72f4f-f0ee-43ac-802e-2e30a1741183'
-        });
-      },
+    ) => {
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.setUsername.next('90a72f4f-f0ee-43ac-802e-2e30a1741183');
+      advance(fixture);
+      expect(gtag.calls.count()).toEqual(1);
+      expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
+        user_id: '90a72f4f-f0ee-43ac-802e-2e30a1741183'
+      });
+    },
     ),
   ));
 
@@ -223,16 +247,16 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
     inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
       angulartics2: Angulartics2,
       angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
-      ) => {
-        fixture = createRoot(RootCmp);
-        angulartics2GoogleGlobalSiteTag.startTracking();
-        angulartics2.setUsername.next({userId: '90a72f4f-f0ee-43ac-802e-2e30a1741183'});
-        advance(fixture);
-        expect(gtag.calls.count()).toEqual(1);
-        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
-          user_id: '90a72f4f-f0ee-43ac-802e-2e30a1741183'
-        });
-      },
+    ) => {
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.setUsername.next({ userId: '90a72f4f-f0ee-43ac-802e-2e30a1741183' });
+      advance(fixture);
+      expect(gtag.calls.count()).toEqual(1);
+      expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
+        user_id: '90a72f4f-f0ee-43ac-802e-2e30a1741183'
+      });
+    },
     ),
   ));
 
@@ -240,19 +264,38 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
     inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
       angulartics2: Angulartics2,
       angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
-      ) => {
-        fixture = createRoot(RootCmp);
-        angulartics2GoogleGlobalSiteTag.startTracking();
-        angulartics2.setUserProperties.next({ test: 1234 });
-        angulartics2.pageTrack.next({ path: '/abc' });
-        advance(fixture);
-        expect(gtag.calls.count()).toEqual(2);
-        expect(gtag).toHaveBeenCalledWith('config', 'UA-111111111-1', {
-          page_path: '/abc',
-          page_location: 'http://localhost:9876/abc',
-          test: 1234
-        });
-      },
+    ) => {
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.setUserProperties.next({ test: 1234 });
+      angulartics2.pageTrack.next({ path: '/abc' });
+      advance(fixture);
+      expect(gtag.calls.count()).toEqual(2);
+      expect(gtag).toHaveBeenCalledWith('config', 'UA-111111111-1', {
+        page_path: '/abc',
+        page_location: 'http://localhost:9876/abc',
+        test: 1234
+      });
+    },
     ),
+  ));
+
+  it('should survive if gtag undefined', fakeAsync(
+    inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
+      angulartics2: Angulartics2,
+      angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
+    ) => {
+      window.gtag = undefined;
+      window.ga = undefined
+
+      fixture = createRoot(RootCmp);
+      angulartics2GoogleGlobalSiteTag.startTracking();
+      angulartics2.setUsername.next('90a72f4f-f0ee-43ac-802e-2e30a1741183');
+      angulartics2.setUserProperties.next({ test: 1234 });
+      angulartics2.userTimings.next({ timingVar: 'load', timingValue: 23, timingCategory: 'performance' });
+      angulartics2.eventTrack.next({ action: 'do' });
+      angulartics2.pageTrack.next({ path: '/abc' });
+      advance(fixture);
+    })
   ));
 });

--- a/src/lib/providers/gst/gst.spec.ts
+++ b/src/lib/providers/gst/gst.spec.ts
@@ -53,6 +53,7 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
         expect(gtag.calls.count()).toEqual(1);
         expect(gtag).toHaveBeenCalledWith('config', 'UA-111111111-1', {
           page_path: '/abc',
+          page_location: 'http://localhost:9876/abc'
         });
       },
     ),
@@ -134,6 +135,122 @@ describe('Angulartics2GoogleGlobalSiteTag', () => {
           value: 33,
           event_category: 'JS Dependencies',
           event_label: 'Google CDN'
+        });
+      },
+    ),
+  ));
+
+  it('should set properties', fakeAsync(
+    inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
+      angulartics2: Angulartics2,
+      angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
+      ) => {
+        fixture = createRoot(RootCmp);
+        angulartics2GoogleGlobalSiteTag.startTracking();
+        angulartics2.setUserProperties.next({
+          'custom_dimension': 'some value'
+        });
+        advance(fixture);
+        expect(gtag.calls.count()).toEqual(1);
+        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
+          'custom_dimension': 'some value'
+        });
+      },
+    ),
+  ));
+
+  it('userProperties should accumulate', fakeAsync(
+    inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
+      angulartics2: Angulartics2,
+      angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
+      ) => {
+        fixture = createRoot(RootCmp);
+        angulartics2GoogleGlobalSiteTag.startTracking();
+        angulartics2.setUserProperties.next({
+          'custom_dimension': 'some value'
+        });
+        angulartics2.setUserProperties.next({
+          'other_dimension': 'other value'
+        });
+        advance(fixture);
+        expect(gtag.calls.count()).toEqual(2);
+        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
+          'custom_dimension': 'some value',
+          'other_dimension': 'other value'
+        });
+      },
+    ),
+  ));
+
+  it('userProperties should allow item removal', fakeAsync(
+    inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
+      angulartics2: Angulartics2,
+      angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
+      ) => {
+        fixture = createRoot(RootCmp);
+        angulartics2GoogleGlobalSiteTag.startTracking();
+        angulartics2.setUserProperties.next({
+          'custom_dimension': 'some value'
+        });
+        angulartics2.setUserProperties.next({
+          'custom_dimension': undefined
+        });
+        advance(fixture);
+        expect(gtag.calls.count()).toEqual(2);
+        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {});
+      },
+    ),
+  ));
+
+  it('should set user id, by string', fakeAsync(
+    inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
+      angulartics2: Angulartics2,
+      angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
+      ) => {
+        fixture = createRoot(RootCmp);
+        angulartics2GoogleGlobalSiteTag.startTracking();
+        angulartics2.setUsername.next('90a72f4f-f0ee-43ac-802e-2e30a1741183');
+        advance(fixture);
+        expect(gtag.calls.count()).toEqual(1);
+        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
+          user_id: '90a72f4f-f0ee-43ac-802e-2e30a1741183'
+        });
+      },
+    ),
+  ));
+
+  it('should set user id, by object', fakeAsync(
+    inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
+      angulartics2: Angulartics2,
+      angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
+      ) => {
+        fixture = createRoot(RootCmp);
+        angulartics2GoogleGlobalSiteTag.startTracking();
+        angulartics2.setUsername.next({userId: '90a72f4f-f0ee-43ac-802e-2e30a1741183'});
+        advance(fixture);
+        expect(gtag.calls.count()).toEqual(1);
+        expect(gtag).toHaveBeenCalledWith('set', 'UA-111111111-1', {
+          user_id: '90a72f4f-f0ee-43ac-802e-2e30a1741183'
+        });
+      },
+    ),
+  ));
+
+  it('user properties should be sent with page track', fakeAsync(
+    inject([Angulartics2, Angulartics2GoogleGlobalSiteTag], (
+      angulartics2: Angulartics2,
+      angulartics2GoogleGlobalSiteTag: Angulartics2GoogleGlobalSiteTag,
+      ) => {
+        fixture = createRoot(RootCmp);
+        angulartics2GoogleGlobalSiteTag.startTracking();
+        angulartics2.setUserProperties.next({ test: 1234 });
+        angulartics2.pageTrack.next({ path: '/abc' });
+        advance(fixture);
+        expect(gtag.calls.count()).toEqual(2);
+        expect(gtag).toHaveBeenCalledWith('config', 'UA-111111111-1', {
+          page_path: '/abc',
+          page_location: 'http://localhost:9876/abc',
+          test: 1234
         });
       },
     ),

--- a/src/lib/providers/gst/gst.ts
+++ b/src/lib/providers/gst/gst.ts
@@ -122,8 +122,6 @@ export class Angulartics2GoogleGlobalSiteTag {
       properties.fatal = true;
     }
 
-    this.cleanProperties(properties);
-
     properties.exDescription = properties.event ? properties.event.stack : properties.description;
 
     this.eventTrack('exception', {
@@ -207,15 +205,15 @@ export class Angulartics2GoogleGlobalSiteTag {
   }
 
   private eventTrackInternal(action: string, properties: any = {}) {
+    this.cleanProperties(properties);
     if (typeof gtag !== 'undefined' && gtag) {
       gtag('event', action, properties);
     }
   }
 
   private cleanProperties(properties: { [key: string]: any }): void {
-    // GA requires that eventValue be an integer, see:
-    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue
-    // https://github.com/luisfarzati/angulartics/issues/81
+    // GA requires that eventValue be an non-negative integer, see:
+    // https://developers.google.com/analytics/devguides/collection/gtagjs/events
     if (properties.value) {
       const parsed = parseInt(properties.value, 10);
       properties.value = isNaN(parsed) ? 0 : parsed;

--- a/src/lib/providers/gst/gst.ts
+++ b/src/lib/providers/gst/gst.ts
@@ -1,21 +1,22 @@
 import { Injectable } from '@angular/core';
 
-import {Angulartics2, GoogleGlobalSiteTagSettings, UserTimings} from 'angulartics2';
-import {UserTimingsGst} from './gst-interfaces';
+import { Angulartics2, GoogleGlobalSiteTagSettings, UserTimings } from 'angulartics2';
+import { EventGst, UserTimingsGst } from './gst-interfaces';
 
 declare var gtag: any;
 declare var ga: any;
 
 export class GoogleGlobalSiteTagDefaults implements GoogleGlobalSiteTagSettings {
-  trackingIds = [];
+  trackingIds: string[] = [];
 
   constructor() {
     if (typeof ga !== 'undefined' && ga) {
       // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/ga-object-methods-reference
       ga(() => {
-        ga.getAll().forEach((tracker) => {
+        ga.getAll().forEach((tracker: any) => {
           const id = tracker.get('trackingId');
-          if (id !== undefined) {
+          // If set both in forRoot and HTML page, we want to avoid duplicates
+          if (id !== undefined && this.trackingIds.indexOf(id) === -1) {
             this.trackingIds.push(id);
           }
         });
@@ -26,6 +27,7 @@ export class GoogleGlobalSiteTagDefaults implements GoogleGlobalSiteTagSettings 
 
 @Injectable({ providedIn: 'root' })
 export class Angulartics2GoogleGlobalSiteTag {
+  dimensionsAndMetrics: { [key: string]: any } = {};
 
   constructor(protected angulartics2: Angulartics2) {
     const defaults = new GoogleGlobalSiteTagDefaults;
@@ -46,6 +48,12 @@ export class Angulartics2GoogleGlobalSiteTag {
     this.angulartics2.userTimings
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe(x => this.userTimings(this.convertTimings(x)));
+    this.angulartics2.setUsername
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x: string) => this.setUsername(x));
+    this.angulartics2.setUserProperties
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x: any) => this.setUserProperties(x));
   }
 
   /**
@@ -57,8 +65,26 @@ export class Angulartics2GoogleGlobalSiteTag {
    */
   pageTrack(path: string) {
     if (typeof gtag !== 'undefined' && gtag) {
+      const params: any = {
+        page_path: path,
+        page_location: window.location.protocol + '//' + window.location.host + path,
+        ...this.dimensionsAndMetrics
+      };
+
+      // Custom map must be reset with all config to stay valid.
+
+      if (this.angulartics2.settings.gst.customMap) {
+        params.custom_map = this.angulartics2.settings.gst.customMap;
+      }
+      if (this.angulartics2.settings.gst.userId) {
+        params.user_id = this.angulartics2.settings.gst.userId;
+      }
+      if (this.angulartics2.settings.gst.anonymizeIp) {
+        params.anonymize_ip = this.angulartics2.settings.gst.anonymizeIp;
+      }
+
       for (const id of this.angulartics2.settings.gst.trackingIds) {
-        gtag('config', id, {'page_path': path});
+        gtag('config', id, { ...params });
       }
     }
   }
@@ -70,15 +96,7 @@ export class Angulartics2GoogleGlobalSiteTag {
    *
    * @param action associated with the event
    */
-  eventTrack(action: string, properties: any) {
-    // TODO: make interface
-    //  @param {string} properties.category
-    //  @param {string} [properties.label]
-    //  @param {number} [properties.value]
-    //  @param {boolean} [properties.noninteraction]
-    // Set a default GST category
-    properties = properties || {};
-
+  eventTrack(action: string, properties: Partial<EventGst> = {}) {
     this.eventTrackInternal(action, {
       event_category: properties.category || 'interaction',
       event_label: properties.label,
@@ -103,6 +121,8 @@ export class Angulartics2GoogleGlobalSiteTag {
       console.log('No "fatal" provided, sending with fatal=true');
       properties.fatal = true;
     }
+
+    this.cleanProperties(properties);
 
     properties.exDescription = properties.event ? properties.event.stack : properties.description;
 
@@ -151,12 +171,54 @@ export class Angulartics2GoogleGlobalSiteTag {
     };
   }
 
-  private eventTrackInternal(action: string, properties: any) {
-    if (typeof gtag === 'undefined' || !gtag) {
-      return;
+  setUsername(userId: string | { userId: string | number }) {
+    this.angulartics2.settings.gst.userId = userId;
+    if (typeof gtag !== 'undefined' && gtag) {
+      for (const id of this.angulartics2.settings.gst.trackingIds) {
+        gtag('set', id, { 'user_id': (typeof userId === 'string' ? userId : userId.userId) });
+      }
     }
+  }
 
-    properties = properties || {};
-    gtag('event', action, properties);
+  setUserProperties(properties: any) {
+    this.setDimensionsAndMetrics(properties);
+  }
+
+  private setDimensionsAndMetrics(properties: { [key: string]: any }) {
+    // We want the dimensions and metrics to accumulate, so we merge with previous value
+    this.dimensionsAndMetrics = {
+      ...this.dimensionsAndMetrics,
+      ...properties
+    };
+
+    // Remove properties that are null or undefined
+    Object.keys(this.dimensionsAndMetrics).forEach(key => {
+      const val = this.dimensionsAndMetrics[key];
+      if (val === undefined || val === null) {
+        delete this.dimensionsAndMetrics[key];
+      }
+    });
+
+    if (typeof gtag !== 'undefined' && gtag) {
+      for (const id of this.angulartics2.settings.gst.trackingIds) {
+        gtag('set', id, this.dimensionsAndMetrics);
+      }
+    }
+  }
+
+  private eventTrackInternal(action: string, properties: any = {}) {
+    if (typeof gtag !== 'undefined' && gtag) {
+      gtag('event', action, properties);
+    }
+  }
+
+  private cleanProperties(properties: { [key: string]: any }): void {
+    // GA requires that eventValue be an integer, see:
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue
+    // https://github.com/luisfarzati/angulartics/issues/81
+    if (properties.value) {
+      const parsed = parseInt(properties.value, 10);
+      properties.value = isNaN(parsed) ? 0 : parsed;
+    }
   }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?

This PR increase the GST provider support.

- Add support for setUsername and setUserProperties
- Add page_location on pageTrack because this seems logical
- Add interface for gst Event properties
- Add support for anonimyzeIp
- Add security check if tracking ID is duplicated in HTML and forRoot config
- Extends documentation accordingly
- Support for custom_map

### Link to open issue?
Mostly linked to #273 #155

### Notes

Multiple setUserProperties will be merge together, instead of using only the most recent one:
```
this.angulartics2.setUserProperties.next({ page_language: 'en_us' });
this.angulartics2.setUserProperties.next({ user_type: 'member' });
this.angulartics2.setUserProperties.next({ page_language: 'en_gb' });
```
will result in `{page_langue: 'en_gb', user_type: 'member'}` being sent with all later event/page track.