### PR TITLE
fix: allow angular 8 peer dependency

### DIFF
--- a/src/lib/core/package.json
+++ b/src/lib/core/package.json
@@ -38,8 +38,8 @@
     "dest": "../../../dist/core"
   },
   "peerDependencies": {
-    "@angular/common": "^6.0.0 || ^7.0.0",
-    "@angular/core": "^6.0.0 || ^7.0.0",
+    "@angular/common": ">=6.0.0 <9.0.0",
+    "@angular/core": ">=6.0.0 <9.0.0",
     "rxjs": "^6.1.0"
   }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Allows angular 8 peer dependency

- **What is the current behavior? Link to open issue?**
When using angular 8 a peer dependency warning is issued by npm

- **What is the new behavior?**
It works with angular 8 without the warning