### PR TITLE
Add page track additional properties and override page name in adobe provider

### DIFF
--- a/src/lib/core/angulartics2-interfaces.ts
+++ b/src/lib/core/angulartics2-interfaces.ts
@@ -4,6 +4,7 @@ export interface EventTrack {
 }
 export interface PageTrack {
   path: string;
+  properties?: any;
 }
 
 /** @link https://developers.google.com/analytics/devguides/collection/analyticsjs/user-timings */

--- a/src/lib/providers/adobeanalytics/adobeanalytics.spec.ts
+++ b/src/lib/providers/adobeanalytics/adobeanalytics.spec.ts
@@ -43,6 +43,18 @@ describe('Angulartics2AdobeAnalytics', () => {
     )),
   );
 
+  it('should override page tracking page name',
+    fakeAsync(inject([Angulartics2, Angulartics2AdobeAnalytics],
+      (angulartics2: Angulartics2, angulartics2AdobeAnalytics: Angulartics2AdobeAnalytics) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.pageTrack.next({ path: '/abc', properties: { pageName: 'override'} });
+        advance(fixture);
+        expect(s.clearVars).toHaveBeenCalled();
+        expect(s.t).toHaveBeenCalledWith({ pageName: 'override' });
+      },
+    )),
+  );
+
   it('should track events with no delay',
     fakeAsync(inject([Angulartics2, Angulartics2AdobeAnalytics],
       (angulartics2: Angulartics2, angulartics2AdobeAnalytics: Angulartics2AdobeAnalytics) => {
@@ -74,6 +86,16 @@ describe('Angulartics2AdobeAnalytics', () => {
         advance(fixture);
         expect(s.tl).toHaveBeenCalledWith(jasmine.any(Object), 'o', 'do');
         expect(window.s.pageName).toEqual('pagename');
+  })));
+
+  it('should override event tracking page name',
+    fakeAsync(inject([Angulartics2, Angulartics2AdobeAnalytics],
+      (angulartics2: Angulartics2, angulartics2AdobeAnalytics: Angulartics2AdobeAnalytics) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat', pageName: 'override' } });
+        advance(fixture);
+        expect(s.tl).toHaveBeenCalledWith(jasmine.any(Object), 'o', 'do');
+        expect(window.s.pageName).toEqual('override');
   })));
 
   it('should set user porperties',

--- a/src/lib/providers/adobeanalytics/adobeanalytics.ts
+++ b/src/lib/providers/adobeanalytics/adobeanalytics.ts
@@ -85,7 +85,7 @@ export class Angulartics2AdobeAnalytics {
   }
 
   private setPageName(properties: any) {
-    if (typeof properties === 'object' && properties.pageName !== 'undefined') {
+    if (typeof properties === 'object' && properties.pageName !== undefined) {
       s.pageName = properties.pageName;
     }  else {
       const path = this.location.path(true);

--- a/src/lib/providers/adobeanalytics/adobeanalytics.ts
+++ b/src/lib/providers/adobeanalytics/adobeanalytics.ts
@@ -14,7 +14,7 @@ export class Angulartics2AdobeAnalytics {
   ) {
     this.angulartics2.pageTrack
       .pipe(this.angulartics2.filterDeveloperMode())
-      .subscribe((x) => this.pageTrack(x.path));
+      .subscribe((x) => this.pageTrack(x.path, x.properties));
     this.angulartics2.eventTrack
       .pipe(this.angulartics2.filterDeveloperMode())
       .subscribe((x) => this.eventTrack(x.action, x.properties));
@@ -22,9 +22,19 @@ export class Angulartics2AdobeAnalytics {
       .subscribe((x) => this.setUserProperties(x));
   }
 
-  pageTrack(path: string) {
+  pageTrack(path: string, properties: any) {
     if (typeof s !== 'undefined' && s) {
       s.clearVars();
+      if (typeof properties === 'object') {
+        // the additional properties are not the ones sent by angulartics but are user defined
+        if (!properties['pageName']){
+          // no page name defined, use the path
+          properties['pageName'] = path;
+        }
+        s.t(properties);
+      } else {
+        s.t({pageName:path});
+      }
       s.t({pageName: path});
     }
   }
@@ -62,7 +72,7 @@ export class Angulartics2AdobeAnalytics {
         if (properties['action']) {
           action = properties['action'];
         }
-        this.setPageName();
+        this.setPageName(properties);
 
         if (action.toUpperCase() === 'DOWNLOAD') {
           s.tl(disableDelay, 'd', linkName);
@@ -75,13 +85,17 @@ export class Angulartics2AdobeAnalytics {
     }
   }
 
-  private setPageName() {
-    const path = this.location.path(true);
-    const hashNdx = path.indexOf('#');
-    if (hashNdx > 0 && hashNdx < path.length) {
-      s.pageName = path.substring(hashNdx + 1);
-    } else {
-      s.pageName = path;
+  private setPageName(properties: any) {
+    if (typeof properties === 'object' && properties.pageName !== 'undefined') {
+      s.pageName = properties.pageName;
+    }  else {
+      const path = this.location.path(true);
+      const hashNdx = path.indexOf('#');
+      if (hashNdx > 0 && hashNdx < path.length) {
+        s.pageName = path.substring(hashNdx + 1);
+      } else {
+        s.pageName = path;
+      }
     }
   }
 

--- a/src/lib/providers/adobeanalytics/adobeanalytics.ts
+++ b/src/lib/providers/adobeanalytics/adobeanalytics.ts
@@ -27,15 +27,14 @@ export class Angulartics2AdobeAnalytics {
       s.clearVars();
       if (typeof properties === 'object') {
         // the additional properties are not the ones sent by angulartics but are user defined
-        if (!properties['pageName']){
+        if (!properties['pageName']) {
           // no page name defined, use the path
           properties['pageName'] = path;
         }
         s.t(properties);
       } else {
-        s.t({pageName:path});
+        s.t({pageName: path});
       }
-      s.t({pageName: path});
     }
   }
 


### PR DESCRIPTION


- **What kind of change does this PR introduce?**
Adds additional properties to Page Track and also add ability within Adobe Omniture provider to override page name and not be forced to use the site URL.

- **What is the current behavior? Link to open issue?**
Not able to add additional parameters to page tracking https://github.com/angulartics/angulartics2/issues/351

- **What is the new behavior?**
page tracking allows passing of additional parameters and adobe can override page name from the url

Note, I am using Angular 5 and Angulartics2 v5.4.0 but those are only tags and not branches so it would be nice if the previous major release versions could have an updated branch so that they can have this feature to.