### PR TITLE
feat(ga): transport for event tracking

### DIFF
--- a/src/lib/providers/ga/ga.ts
+++ b/src/lib/providers/ga/ga.ts
@@ -114,17 +114,13 @@ export class Angulartics2GoogleAnalytics {
         page: properties.page || location.hash.substring(1) || location.pathname,
         userId: this.angulartics2.settings.ga.userId,
         hitCallback: properties.hitCallback,
+        ... this.angulartics2.settings.ga.transport && { transport: this.angulartics2.settings.ga.transport }
       };
 
       // add custom dimensions and metrics
       this.setDimensionsAndMetrics(properties);
-      if (this.angulartics2.settings.ga.transport) {
-        ga('send', 'event', eventOptions, {
-          transport: this.angulartics2.settings.ga.transport,
-        });
-      } else {
-        ga('send', 'event', eventOptions);
-      }
+
+      ga('send', 'event', eventOptions);
 
       for (const accountName of this.angulartics2.settings.ga.additionalAccountNames) {
         ga(accountName + '.send', 'event', eventOptions);


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

GA provider for analytics.js implementations has a (what appears to be long standing) bug that doesn't correctly pass the "transport" option to GA.

- **What is the current behavior? Link to open issue?**

When transport is set to "beacon" the resulting hit is still sent using an image by default.

- **What is the new behavior?**

When transport is set to "beacon" eventTrack() now correctly uses analytics.js' support for navigator.sendBeacon().

The core of the problem seems to be an incorrect use of the GA API. 

The ga.send() function only accepts a single fieldsObject: https://developers.google.com/analytics/devguides/collection/analyticsjs/tracker-object-reference#send

Demonstration of the underlying issue: https://gist.githack.com/goosmurf/9fec28db0e9747baa70a0120af59e389/raw/f2a18b1cdde9bcfb33fb272c05d5fcaa1cbc95a7/mixed-transport.html

Watch the network tab in dev tools and you'll see that the "Broken beacon" is sent using an image, whereas the "Working beacon" is sent via navigator.sendBeacon (identifiable by both the HTTP method being POST as well as the Initiator on the request).