### PR TITLE
feat(segment): allow segment identity to be cleared

### DIFF
--- a/src/lib/core/angulartics2-core.ts
+++ b/src/lib/core/angulartics2-core.ts
@@ -22,6 +22,7 @@ export class Angulartics2 {
   setSuperProperties = new ReplaySubject<any>(10);
   setSuperPropertiesOnce = new ReplaySubject<any>(10);
   userTimings = new ReplaySubject<UserTimings>(10);
+  unsetUserProperties = new ReplaySubject<any>(10);
 
   constructor(
     private tracker: RouterlessTracking,

--- a/src/lib/providers/segment/segment.spec.ts
+++ b/src/lib/providers/segment/segment.spec.ts
@@ -27,7 +27,8 @@ describe('Angulartics2Segment', () => {
       page: jasmine.createSpy('page'),
       track: jasmine.createSpy('track'),
       identify: jasmine.createSpy('identify'),
-      alias: jasmine.createSpy('alias')
+      alias: jasmine.createSpy('alias'),
+      reset:  jasmine.createSpy('identify'),
     };
 
     const provider: Angulartics2Segment = TestBed.get(Angulartics2Segment);
@@ -99,4 +100,14 @@ describe('Angulartics2Segment', () => {
     ),
   );
 
+  it('should unset user properties',
+    fakeAsync(inject([Angulartics2, Angulartics2Segment],
+      (angulartics2: Angulartics2, angulartics2Segment: Angulartics2Segment) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.unsetUserProperties.next();
+        advance(fixture);
+        expect(analytics.reset).toHaveBeenCalled();
+      }),
+    ),
+  );
 });

--- a/src/lib/providers/segment/segment.ts
+++ b/src/lib/providers/segment/segment.ts
@@ -78,6 +78,15 @@ export class Angulartics2Segment {
   }
 
   /**
+   * https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#reset--logout
+   *
+   * analytics.reset();
+   */
+  unsetUserProperties() {
+    analytics.reset();
+  }
+
+  /**
    * https://segment.com/docs/libraries/analytics.js/#alias
    *
    * analytics.alias(userId, previousId, options, callback);


### PR DESCRIPTION
From Segment docs:
"Note: The user data will remain cached until you explicitly clear the browser cache or call reset.
So don’t forget to call reset upon user log out!"

- **What kind of change does this PR introduce?**
When you call `identity` in segment it stores the user data in local storage.
Segment provides a `reset` method to call to clear this data.
This PR introduces a way of calling `reset`.


- **What is the current behavior?**
There is currently no way to call `reset` and clear the users identity. 


- **What is the new behavior?**
Allows for clearing the users identity. 
