### PR TITLE
docs: updates readme to include correct ng support mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Latest version available for each version of Angular
 | 8.3.0        | 8.x       |
 | 9.1.0        | 9.x       |
 | 10.1.0       | 10.x      |
-| latest       | 12.x      |
+| 11.0.0       | 12.x      |
+| latest       | 13.x      |
 
 ## Installation
 


### PR DESCRIPTION
The current version doesn't include in the Readme the updated mapping for NG 13, and NG12. This fixes it.

Note that there is already a PR #441  open with the same idea, but the `latest` of Angulartics **does not work with ng12**.

- **What kind of change does this PR introduce?**
Documentation

- **What is the current behavior? Link to open issue?**
If installing latest version with `npm` on an Angular v12 the project fails because the version is unsupported.

- **What is the new behavior?**
This Documentation change updates the table to the correct version mapping