### PR TITLE
feat(Pyze): updated profile api's

### DIFF
--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -29,7 +29,8 @@
     "kissmetrics",
     "segment",
     "amplitude",
-    "baidu"
+    "baidu",
+    "pyze"
   ],
   "ngPackage": {
     "lib": {

--- a/src/lib/providers/pyze/pyze.spec.ts
+++ b/src/lib/providers/pyze/pyze.spec.ts
@@ -27,8 +27,8 @@ describe('Angulartics2Pyze', () => {
       postCustomEventWithAttributes: jasmine.createSpy('postCustomEventWithAttributes'),
     };
     window.PyzeIdentity = PyzeIdentity = {
-      setUserIdentifier: jasmine.createSpy('setUserIdentifier'),
-      postTraits: jasmine.createSpy('postTraits'),
+      setUserProfile: jasmine.createSpy('setUserProfile'),
+      updateUserProfile: jasmine.createSpy('updateUserProfile'),
     };
 
     const provider: Angulartics2Pyze = TestBed.inject(Angulartics2Pyze);
@@ -73,7 +73,7 @@ describe('Angulartics2Pyze', () => {
         fixture = createRoot(RootCmp);
         angulartics2.setUsername.next('testId');
         advance(fixture);
-        expect(PyzeIdentity.setUserIdentifier).toHaveBeenCalledWith('testId');
+        expect(PyzeIdentity.setUserProfile).toHaveBeenCalledWith('testId');
       },
     ),
   ));
@@ -89,7 +89,7 @@ describe('Angulartics2Pyze', () => {
           lastName: 'Lobo',
         });
         advance(fixture);
-        expect(PyzeIdentity.postTraits).toHaveBeenCalledWith({
+        expect(PyzeIdentity.updateUserProfile).toHaveBeenCalledWith({},{
           userId: 'testId',
           firstName: 'Jess',
           lastName: 'Lobo',

--- a/src/lib/providers/pyze/pyze.ts
+++ b/src/lib/providers/pyze/pyze.ts
@@ -9,8 +9,8 @@ declare var PyzeIdentity: any;
 @Injectable({ providedIn: 'root' })
 export class Angulartics2Pyze {
   constructor(private angulartics2: Angulartics2) {
-    this.angulartics2.setUsername.subscribe((x: string) => this.setUserId(x));
-    this.angulartics2.setUserProperties.subscribe(x => this.postTraits(x));
+    this.angulartics2.setUsername.subscribe((x: string) => this.setUserProfile(x));
+    this.angulartics2.setUserProperties.subscribe(x => this.updateUserProfile(x));
   }
 
   startTracking(): void {
@@ -42,9 +42,9 @@ export class Angulartics2Pyze {
     }
   }
 
-  setUserId(userId: string) {
+  setUserProfile(userId: string) {
     try {
-      PyzeIdentity.setUserIdentifier(userId);
+      PyzeIdentity.setUserProfile(userId);
     } catch (e) {
       if (!(e instanceof ReferenceError)) {
         throw e;
@@ -52,9 +52,9 @@ export class Angulartics2Pyze {
     }
   }
 
-  postTraits(properties: string) {
+  updateUserProfile(properties: string) {
     try {
-      PyzeIdentity.postTraits(properties);
+      PyzeIdentity.updateUserProfile({},properties)
     } catch (e) {
       if (!(e instanceof ReferenceError)) {
         throw e;


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Updated deprecated profile API's

- **What is the current behavior? Link to open issue?**
setUsername, setUserProperties are pointing to old profile API's

- **What is the new behavior?**
setUsername, setUserProperties are pointed to new profile API's