### PR TITLE
fix(Pyze) : update_profile_api_type_fix

### DIFF
--- a/src/lib/providers/pyze/pyze.ts
+++ b/src/lib/providers/pyze/pyze.ts
@@ -52,7 +52,7 @@ export class Angulartics2Pyze {
     }
   }
 
-  updateUserProfile(properties: string) {
+  updateUserProfile(properties: any) {
     try {
       PyzeIdentity.updateUserProfile({},properties)
     } catch (e) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
This fixes the type variable for update_profile_api

- **What is the current behavior? Link to open issue?**
Update profile api type was -> string

- **What is the new behavior?**
updated string to any