### PR TITLE
feat(posthog): add option to set a group

### DIFF
--- a/src/lib/providers/posthog/posthog.spec.ts
+++ b/src/lib/providers/posthog/posthog.spec.ts
@@ -22,6 +22,7 @@ describe('Angulartics2Posthog', () => {
       capture: jasmine.createSpy('capture'),
       identify: jasmine.createSpy('identify'),
       alias: jasmine.createSpy('alias'),
+      group: jasmine.createSpy('group'),
     };
 
     const provider: Angulartics2Posthog = TestBed.inject(Angulartics2Posthog);
@@ -166,4 +167,16 @@ describe('Angulartics2Posthog', () => {
       },
     ),
   ));
+
+  it('should set group properties', fakeAsync(
+    inject(
+      [Angulartics2, Angulartics2Posthog],
+      (angulartics2: Angulartics2, angulartics2Posthog: Angulartics2Posthog) => {
+        fixture = createRoot(RootCmp);
+        angulartics2Posthog.setGroup('company', '123', { name: 'Company name' });
+        advance(fixture);
+        expect(posthog.group).toHaveBeenCalledWith('company', '123', { name: 'Company name' });
+      }
+    )
+  ))
 });

--- a/src/lib/providers/posthog/posthog.ts
+++ b/src/lib/providers/posthog/posthog.ts
@@ -116,4 +116,14 @@ export class Angulartics2Posthog {
       }
     }
   }
+
+  setGroup(groupType: string, groupKey: string, properties: any) {
+    try {
+      posthog.group(groupType, groupKey, properties);
+    } catch (e) {
+      if (!(e instanceof ReferenceError)) {
+        throw e;
+      }
+    }
+  }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Adds a new option on Posthog provider.

- **What is the current behavior? Link to open issue?**
No current behavior.

- **What is the new behavior?**
Users are able to set a group properties via Posthog provider.