### PR TITLE
Application Insights provider is not setting the name property properly in the custom events...

### DIFF
--- a/src/lib/providers/appinsights/appinsights.ts
+++ b/src/lib/providers/appinsights/appinsights.ts
@@ -110,7 +110,7 @@ export class Angulartics2AppInsights {
    * @link https://github.com/Microsoft/ApplicationInsights-JS/blob/master/API-reference.md#trackevent
    */
   eventTrack(name: string, properties: { [name: string]: string }) {
-    appInsights.trackEvent(name, properties, this.measurements);
+    appInsights.trackEvent({name : name, properties : properties, measurements: this.measurements});
   }
 
   /**


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
After switching to the new CDN URLs recommended by Application Insights, it was found that the name property in the custom event is getting recorded as Not_available. 
The fix is to call the trackEvent method on the underlying provider with the current parameter structure.

- **What is the current behavior? Link to open issue?**


- **What is the new behavior?**
